### PR TITLE
Configuring Checkstyle Plugin for Builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,34 @@
           </executions>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <version>3.0.0</version>
+          <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>8.13</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <configLocation>google_checks.xml</configLocation>
+            <encoding>UTF-8</encoding>
+            <consoleOutput>true</consoleOutput>
+            <failsOnError>true</failsOnError>
+            <failOnViolation>true</failOnViolation>
+          </configuration>
+          <executions>
+            <execution>
+              <id>checkstyle</id>
+              <phase>validate</phase>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <groupId>org.assertj</groupId>
           <artifactId>assertj-assertions-generator-maven-plugin</artifactId>
           <version>2.2.0</version>
@@ -250,7 +278,8 @@
           <configuration>
             <aggregate>true</aggregate>
             <headerDefinitions>
-              <headerDefinition>${feign.basedir}/src/resources/header-definition.xml</headerDefinition>
+              <headerDefinition>${feign.basedir}/src/resources/header-definition.xml
+              </headerDefinition>
             </headerDefinitions>
             <header>NOTICE</header>
             <excludes>
@@ -293,6 +322,10 @@
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
   <reporting>
@@ -304,6 +337,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jxr-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <configuration>
+          <configLocation>google_checks.xml</configLocation>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>


### PR DESCRIPTION
Checkstyle, using `google_checks` is now enabled for all builds
as part of the `validate` stage.  This will report any errors
and violations at the beginning of the build.