### PR TITLE
Updating CircleCI builds to work in offline mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - feignx-dependencies-
 
-      - run: mvn dependency:go-offline
+      - run: mvn go-offline:resolve-dependencies dependency:resolve-plugins dependency:go-offline
 
       - save_cache:
           paths:
@@ -38,7 +38,7 @@ jobs:
           key: feignx-dependencies-{{ checksum "pom.xml" }}
 
       # run tests!
-      - run: mvn clean test
+      - run: mvn -o test
 
       - store_test_results:
           path: target/surefire-reports

--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,21 @@
           </configuration>
         </plugin>
         <plugin>
+          <groupId>de.qaware.maven</groupId>
+          <artifactId>go-offline-maven-plugin</artifactId>
+          <version>1.1.0</version>
+            <configuration>
+              <dynamicDependencies>
+                <DynamicDependency>
+                  <groupId>org.apache.maven.surefire</groupId>
+                  <artifactId>surefire-junit-platform</artifactId>
+                  <version>2.22.2</version>
+                  <repositoryType>PLUGIN</repositoryType>
+                </DynamicDependency>
+              </dynamicDependencies>
+            </configuration>
+        </plugin>
+        <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>3.0</version>
@@ -313,6 +328,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>de.qaware.maven</groupId>
+        <artifactId>go-offline-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>com.mycila</groupId>


### PR DESCRIPTION
This requires update to the circle configuration, specifically
modifying the cache and run commands to pull every dependency,
go offline, then run the tests in offline mode.