### PR TITLE
Adding Codecov to Circle Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,9 @@
 #
 # Check https://circleci.com/docs/2.0/language-java/ for more details
 #
-version: 2
+version: 2.1
+orbs:
+  codecov: codecov/codecov@1.0.4
 jobs:
   build:
     docker:
@@ -42,3 +44,6 @@ jobs:
 
       - store_test_results:
           path: target/surefire-reports
+
+      - codecov/upload:
+          file: feignx-core/target/site/jacoco/jacoco.xml

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,7 @@
             </execution>
             <execution>
               <id>report</id>
+              <phase>test</phase>
               <goals>
                 <goal>report</goal>
               </goals>


### PR DESCRIPTION
Enabled Jacoco Reports for test phases and configured
CircleCI to upload reports to Codecov