### PR TITLE
GH-16: Adding Test Module for Aggregate Code Coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,48 +2,40 @@
 #
 # Check https://circleci.com/docs/2.0/language-java/ for more details
 #
+
+# our job defaults
+defaults: &defaults
+  docker:
+    - image: circleci/openjdk:11.0.2
+  working_directory: ~/feignx
+  environment:
+    # Customize the JVM maximum heap limit
+    MAVEN_OPTS: -Xmx3200m
+
 version: 2.1
 orbs:
   codecov: codecov/codecov@1.0.4
 jobs:
   build:
-    docker:
-      # specify the version you desire here
-      - image: circleci/openjdk:11.0.2
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
-
-    working_directory: ~/feignx
-
-    environment:
-      # Customize the JVM maximum heap limit
-      MAVEN_OPTS: -Xmx3200m
-
+    <<: *defaults
     steps:
       - checkout
-
-      # Download and cache dependencies
       - restore_cache:
           keys:
             - feignx-dependencies-{{ checksum "pom.xml" }}
-            # fallback to using the latest cache if no exact match is found
             - feignx-dependencies-
-
-      - run: mvn go-offline:resolve-dependencies dependency:resolve-plugins dependency:go-offline
-
+      - run: mvn dependency:resolve-plugins go-offline:resolve-dependencies install -DskipTests=true
       - save_cache:
           paths:
             - ~/.m2
           key: feignx-dependencies-{{ checksum "pom.xml" }}
-
-      # run tests!
       - run: mvn -o test
-
       - store_test_results:
           path: target/surefire-reports
-
       - codecov/upload:
-          file: feignx-core/target/site/jacoco/jacoco.xml
+          file: tests/target/site/jacoco-aggregate/jacoco.xml
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
   <version>0.0.1-SNAPSHOT</version>
   <modules>
     <module>core</module>
+    <module>tests</module>
   </modules>
 
   <properties>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2019 OpenFeign Contributors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>feignx</artifactId>
+    <groupId>io.github.openfeign.incubating</groupId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>feign-tests</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <properties>
+    <feign.basedir>${project.basedir}/..</feign.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.github.openfeign.incubating</groupId>
+      <artifactId>feignx-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>aggregate</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Fixes #16 

Adding tests module for coverage report aggregation

The jacoco aggregate report plugin requires a module that
depends on all of the projects to aggregate.  This change
creates a new functional test module for that purpose.

Circle CI Configuration has been updated to report the
aggregate to Codecov.