### PR TITLE
Adding AsyncTargetMethodHandler

### DIFF
--- a/core/src/main/java/feign/Client.java
+++ b/core/src/main/java/feign/Client.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 

--- a/core/src/main/java/feign/ExceptionHandler.java
+++ b/core/src/main/java/feign/ExceptionHandler.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 

--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 

--- a/core/src/main/java/feign/FeignConfiguration.java
+++ b/core/src/main/java/feign/FeignConfiguration.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 

--- a/core/src/main/java/feign/FeignConfigurationBuilder.java
+++ b/core/src/main/java/feign/FeignConfigurationBuilder.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 

--- a/core/src/main/java/feign/Header.java
+++ b/core/src/main/java/feign/Header.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 

--- a/core/src/main/java/feign/Logger.java
+++ b/core/src/main/java/feign/Logger.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 

--- a/core/src/main/java/feign/Request.java
+++ b/core/src/main/java/feign/Request.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 

--- a/core/src/main/java/feign/RequestEncoder.java
+++ b/core/src/main/java/feign/RequestEncoder.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 

--- a/core/src/main/java/feign/RequestInterceptor.java
+++ b/core/src/main/java/feign/RequestInterceptor.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 

--- a/core/src/main/java/feign/RequestOptions.java
+++ b/core/src/main/java/feign/RequestOptions.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 

--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 

--- a/core/src/main/java/feign/ResponseDecoder.java
+++ b/core/src/main/java/feign/ResponseDecoder.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 

--- a/core/src/main/java/feign/Target.java
+++ b/core/src/main/java/feign/Target.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 

--- a/core/src/main/java/feign/TargetMethodDefinition.java
+++ b/core/src/main/java/feign/TargetMethodDefinition.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 
@@ -111,8 +111,8 @@ public final class TargetMethodDefinition {
    *
    * @return return Type.
    */
-  public Class<?> getReturnType() {
-    return returnType.getType();
+  public TypeDefinition getReturnType() {
+    return returnType;
   }
 
   /**

--- a/core/src/main/java/feign/TargetMethodHandler.java
+++ b/core/src/main/java/feign/TargetMethodHandler.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 

--- a/core/src/main/java/feign/TargetMethodHandlerFactory.java
+++ b/core/src/main/java/feign/TargetMethodHandlerFactory.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 

--- a/core/src/main/java/feign/contract/AbstractAnnotationDrivenContract.java
+++ b/core/src/main/java/feign/contract/AbstractAnnotationDrivenContract.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.contract;
 

--- a/core/src/main/java/feign/contract/Body.java
+++ b/core/src/main/java/feign/contract/Body.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.contract;
 

--- a/core/src/main/java/feign/contract/FeignContract.java
+++ b/core/src/main/java/feign/contract/FeignContract.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.contract;
 

--- a/core/src/main/java/feign/contract/Header.java
+++ b/core/src/main/java/feign/contract/Header.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.contract;
 

--- a/core/src/main/java/feign/contract/Headers.java
+++ b/core/src/main/java/feign/contract/Headers.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.contract;
 

--- a/core/src/main/java/feign/contract/Param.java
+++ b/core/src/main/java/feign/contract/Param.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.contract;
 

--- a/core/src/main/java/feign/contract/Request.java
+++ b/core/src/main/java/feign/contract/Request.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.contract;
 

--- a/core/src/main/java/feign/decoder/AbstractResponseDecoder.java
+++ b/core/src/main/java/feign/decoder/AbstractResponseDecoder.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.decoder;
 

--- a/core/src/main/java/feign/decoder/StringDecoder.java
+++ b/core/src/main/java/feign/decoder/StringDecoder.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.decoder;
 

--- a/core/src/main/java/feign/encoder/StringEncoder.java
+++ b/core/src/main/java/feign/encoder/StringEncoder.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.encoder;
 

--- a/core/src/main/java/feign/exception/FeignException.java
+++ b/core/src/main/java/feign/exception/FeignException.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.exception;
 

--- a/core/src/main/java/feign/http/HttpException.java
+++ b/core/src/main/java/feign/http/HttpException.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.http;
 

--- a/core/src/main/java/feign/http/HttpHeader.java
+++ b/core/src/main/java/feign/http/HttpHeader.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.http;
 

--- a/core/src/main/java/feign/http/HttpMethod.java
+++ b/core/src/main/java/feign/http/HttpMethod.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.http;
 

--- a/core/src/main/java/feign/http/HttpRequest.java
+++ b/core/src/main/java/feign/http/HttpRequest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.http;
 

--- a/core/src/main/java/feign/http/HttpResponse.java
+++ b/core/src/main/java/feign/http/HttpResponse.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.http;
 

--- a/core/src/main/java/feign/http/RequestSpecification.java
+++ b/core/src/main/java/feign/http/RequestSpecification.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.http;
 

--- a/core/src/main/java/feign/http/client/UrlConnectionClient.java
+++ b/core/src/main/java/feign/http/client/UrlConnectionClient.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.http.client;
 

--- a/core/src/main/java/feign/impl/AbstractFeignConfigurationBuilder.java
+++ b/core/src/main/java/feign/impl/AbstractFeignConfigurationBuilder.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.impl;
 

--- a/core/src/main/java/feign/impl/AbstractTarget.java
+++ b/core/src/main/java/feign/impl/AbstractTarget.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.impl;
 

--- a/core/src/main/java/feign/impl/AsyncTargetMethodHandler.java
+++ b/core/src/main/java/feign/impl/AsyncTargetMethodHandler.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.impl;
+
+import feign.Client;
+import feign.ExceptionHandler;
+import feign.Logger;
+import feign.RequestEncoder;
+import feign.RequestInterceptor;
+import feign.Response;
+import feign.ResponseDecoder;
+import feign.TargetMethodDefinition;
+import feign.exception.FeignException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+import java.util.concurrent.RunnableFuture;
+import java.util.function.Supplier;
+
+/**
+ * Method Handler that deals with asynchronous return types, such as {@link Future}.
+ */
+public class AsyncTargetMethodHandler extends AbstractTargetMethodHandler {
+
+  /**
+   * Creates a new Abstract Target HttpMethod Handler.
+   *
+   * @param targetMethodDefinition containing the method configuration.
+   * @param encoder to use when preparing the request.
+   * @param interceptors to apply to the request before processing.
+   * @param client to send the request and create the response.
+   * @param decoder to use when parsing the response.
+   * @param exceptionHandler to delegate to when an exception occurs.
+   * @param executor to execute the request on.
+   * @param logger for logging requests and responses.
+   */
+  AsyncTargetMethodHandler(TargetMethodDefinition targetMethodDefinition,
+      RequestEncoder encoder, List<RequestInterceptor> interceptors,
+      Client client, ResponseDecoder decoder, ExceptionHandler exceptionHandler,
+      Executor executor, Logger logger) {
+    super(targetMethodDefinition, encoder, interceptors, client, decoder, exceptionHandler,
+        executor, logger);
+  }
+
+  /**
+   * Handles the results of the Request execution by wrapping the result in a new {@link
+   * CompletableFuture} containing the decoded Response body.  The method handler's
+   * Executor is used for this future.
+   *
+   * @param response Future containing the results of the request.
+   * @return a {@link CompletableFuture} reference wrapping the results.
+   */
+  @Override
+  protected Object handleResponse(RunnableFuture<Response> response) {
+
+    /* wrap the future in a completable, so we can decode when complete */
+    return CompletableFuture
+        .supplyAsync(new ResponseSupplier(this.getTag(), response), this.getExecutor())
+        .handle((resp, throwable) -> {
+          if (throwable != null) {
+            getExceptionHandler().accept(throwable);
+          } else {
+            return decode(resp);
+          }
+          return null;
+        });
+  }
+
+  /**
+   * Simple Supplier that waits for the Response to be fulfilled.  This method blocks
+   * until the supplied Future is resolved.
+   */
+  static class ResponseSupplier implements Supplier<Response> {
+
+    private final String method;
+    private final RunnableFuture<Response> task;
+
+    ResponseSupplier(String method, RunnableFuture<Response> task) {
+      this.method = method;
+      this.task = task;
+    }
+
+    /**
+     * Block waiting for the response.
+     *
+     * @return the response.
+     */
+    @Override
+    public Response get() {
+      try {
+        /* wait for the response */
+        return task.get();
+      } catch (Exception ex) {
+        throw new FeignException(ex.getMessage(), ex, method);
+      }
+    }
+  }
+}

--- a/core/src/main/java/feign/impl/BaseFeignConfiguration.java
+++ b/core/src/main/java/feign/impl/BaseFeignConfiguration.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.impl;
 

--- a/core/src/main/java/feign/impl/BlockingTargetMethodHandler.java
+++ b/core/src/main/java/feign/impl/BlockingTargetMethodHandler.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.impl;
 

--- a/core/src/main/java/feign/impl/UriTarget.java
+++ b/core/src/main/java/feign/impl/UriTarget.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.impl;
 

--- a/core/src/main/java/feign/impl/type/AbstractTypeDefinition.java
+++ b/core/src/main/java/feign/impl/type/AbstractTypeDefinition.java
@@ -16,33 +16,44 @@
 
 package feign.impl.type;
 
-import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.Future;
 
 /**
- * Type Definition for a {@link GenericArrayType}, a ParameterizedType with an Array supplied
- * as the Type Variable.
+ * Basic Type Definition.
  */
-public class GenericArrayTypeDefinition extends AbstractTypeDefinition implements GenericArrayType {
-
-  private final TypeDefinition genericComponentType;
+public abstract class AbstractTypeDefinition implements TypeDefinition, Type {
 
   /**
-   * Creates a new {@link GenericArrayTypeDefinition}.
+   * Returns the type defined.
    *
-   * @param genericComponentType containing the Type to define.
+   * @return defined type.
    */
-  GenericArrayTypeDefinition(TypeDefinition genericComponentType) {
-    this.genericComponentType = genericComponentType;
+  @Override
+  public Class<?> getActualType() {
+    return this.getType();
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
-  public Class<?> getType() {
-    return this.genericComponentType.getType();
+  public boolean isCollectionLike() {
+    Class<?> type = this.getType();
+    return type.isArray()
+        || Iterable.class.isAssignableFrom(type)
+        || Collection.class.isAssignableFrom(type);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
-  public Type getGenericComponentType() {
-    return this.genericComponentType;
+  public boolean isContainer() {
+    Class<?> type = this.getType();
+    return Future.class.isAssignableFrom(type);
   }
+
 }

--- a/core/src/main/java/feign/impl/type/ClassTypeDefinition.java
+++ b/core/src/main/java/feign/impl/type/ClassTypeDefinition.java
@@ -12,16 +12,14 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.impl.type;
-
-import java.lang.reflect.Type;
 
 /**
  * Type Definition for a concrete Class.
  */
-public class ClassTypeDefinition implements TypeDefinition, Type {
+public class ClassTypeDefinition extends AbstractTypeDefinition {
 
   private final Class<?> type;
 
@@ -34,8 +32,14 @@ public class ClassTypeDefinition implements TypeDefinition, Type {
     this.type = type;
   }
 
+  /**
+   * The concrete type.
+   *
+   * @return the wrapped type.
+   */
   @Override
   public Class<?> getType() {
     return this.type;
   }
+
 }

--- a/core/src/main/java/feign/impl/type/ParameterizedTypeDefinition.java
+++ b/core/src/main/java/feign/impl/type/ParameterizedTypeDefinition.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.impl.type;
 
@@ -22,11 +22,12 @@ import java.lang.reflect.Type;
 /**
  * Type Definition for a {@link ParameterizedType}, the simplest type of Generic.
  */
-public class ParameterizedTypeDefinition implements ParameterizedType, TypeDefinition {
+public class ParameterizedTypeDefinition extends AbstractTypeDefinition implements
+    ParameterizedType {
 
   private final Type owner;
   private final Type raw;
-  private final Type[] arguments;
+  private final TypeDefinition[] arguments;
 
   /**
    * Creates a new ParameterizedTypeDefinition.
@@ -35,29 +36,67 @@ public class ParameterizedTypeDefinition implements ParameterizedType, TypeDefin
    * @param raw type contained.
    * @param arguments for each TypeVariable in the type definition.
    */
-  ParameterizedTypeDefinition(Type owner, Type raw, Type... arguments) {
+  ParameterizedTypeDefinition(Type owner, Type raw, TypeDefinition... arguments) {
     this.owner = owner;
     this.raw = raw;
     this.arguments = arguments.clone();
   }
 
+  /**
+   * Return the type declared.
+   *
+   * @return the actual type being managed.
+   */
+  @Override
+  public Class<?> getActualType() {
+    if (this.isContainer() || this.isCollectionLike()) {
+      /* use the first type argument here */
+      TypeDefinition actualType = this.arguments[0];
+      return actualType.getType();
+    }
+    return super.getActualType();
+  }
+
+  /**
+   * This type defined.
+   *
+   * @return the defined type.
+   */
   @Override
   public Class<?> getType() {
+    /* use the raw type */
     return (Class<?>) this.getRawType();
   }
 
+  /**
+   * Return the Type Arguments defined.
+   *
+   * @return an array of Types
+   */
   @Override
   public Type[] getActualTypeArguments() {
     return arguments.clone();
   }
 
+  /**
+   * The Raw type representing the class or interface declared.
+   *
+   * @return the declared type.
+   */
   @Override
   public Type getRawType() {
     return this.raw;
   }
 
+  /**
+   * The Type representing the that this type is a member of.
+   *
+   * @return the owner type, can be {@literal null}.
+   */
   @Override
   public Type getOwnerType() {
     return this.owner;
   }
+
+
 }

--- a/core/src/main/java/feign/impl/type/ParameterizedTypeDefinition.java
+++ b/core/src/main/java/feign/impl/type/ParameterizedTypeDefinition.java
@@ -49,12 +49,9 @@ public class ParameterizedTypeDefinition extends AbstractTypeDefinition implemen
    */
   @Override
   public Class<?> getActualType() {
-    if (this.isContainer() || this.isCollectionLike()) {
-      /* use the first type argument here */
-      TypeDefinition actualType = this.arguments[0];
-      return actualType.getType();
-    }
-    return super.getActualType();
+    /* use the first type argument here */
+    TypeDefinition actualType = this.arguments[0];
+    return actualType.getType();
   }
 
   /**

--- a/core/src/main/java/feign/impl/type/TypeDefinition.java
+++ b/core/src/main/java/feign/impl/type/TypeDefinition.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.impl.type;
 
@@ -29,5 +29,33 @@ public interface TypeDefinition extends Type {
    * @return class reference.
    */
   Class<?> getType();
+
+  /**
+   * Return the actual type for this definition.  For basic types, this will be the same as
+   * {@link #getType()}, but for parameterized types that are collections or containers, this
+   * will return the type contained.
+   *
+   * @return the actual type reference.
+   */
+  Class<?> getActualType();
+
+  /**
+   * Returns whether this definition is considered a Collection, which is basically anything
+   * that extends {@link Iterable}.  The expectation here is that, if a type is collection like,
+   * then {@link #getType()} will return an {@link Iterable} type.
+   *
+   * @return if this definition is for a Collection.
+   */
+  boolean isCollectionLike();
+
+  /**
+   * Returns whether this definition is one of a select type of objects that act as containers.
+   * Container types act as vehicles to decorate the actual types.  The expectation here is that
+   * {@link #getActualType()} will return the contained type.  Some examples are
+   * {@link java.util.Optional} and {@link java.util.concurrent.Future}.
+   *
+   * @return if this definition represents a contained type.
+   */
+  boolean isContainer();
 
 }

--- a/core/src/main/java/feign/impl/type/TypeDefinitionFactory.java
+++ b/core/src/main/java/feign/impl/type/TypeDefinitionFactory.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.impl.type;
 

--- a/core/src/main/java/feign/impl/type/WildCardTypeDefinition.java
+++ b/core/src/main/java/feign/impl/type/WildCardTypeDefinition.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.impl.type;
 
@@ -22,10 +22,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Type Definition for a Parameterized Type where one of the Type Variable's defined is a
- * {@code ?} wildcard.
+ * Type Definition for a Parameterized Type where one of the Type Variable's defined is a {@code ?}
+ * wildcard.
  */
-public class WildCardTypeDefinition implements WildcardType, TypeDefinition {
+public class WildCardTypeDefinition extends AbstractTypeDefinition implements WildcardType {
 
   private List<TypeDefinition> upperBounds;
   private List<TypeDefinition> lowerBounds;

--- a/core/src/main/java/feign/logging/AbstractLogger.java
+++ b/core/src/main/java/feign/logging/AbstractLogger.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.logging;
 

--- a/core/src/main/java/feign/logging/SimpleLogger.java
+++ b/core/src/main/java/feign/logging/SimpleLogger.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.logging;
 

--- a/core/src/main/java/feign/proxy/GuardMethodHandler.java
+++ b/core/src/main/java/feign/proxy/GuardMethodHandler.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.proxy;
 

--- a/core/src/main/java/feign/proxy/ProxyFeign.java
+++ b/core/src/main/java/feign/proxy/ProxyFeign.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.proxy;
 

--- a/core/src/main/java/feign/proxy/ProxyTarget.java
+++ b/core/src/main/java/feign/proxy/ProxyTarget.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.proxy;
 

--- a/core/src/main/java/feign/support/Assert.java
+++ b/core/src/main/java/feign/support/Assert.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.support;
 

--- a/core/src/main/java/feign/support/StringUtils.java
+++ b/core/src/main/java/feign/support/StringUtils.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.support;
 

--- a/core/src/main/java/feign/template/Chunk.java
+++ b/core/src/main/java/feign/template/Chunk.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/main/java/feign/template/CompositeExpression.java
+++ b/core/src/main/java/feign/template/CompositeExpression.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/main/java/feign/template/DotExpression.java
+++ b/core/src/main/java/feign/template/DotExpression.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/main/java/feign/template/Expression.java
+++ b/core/src/main/java/feign/template/Expression.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/main/java/feign/template/Expressions.java
+++ b/core/src/main/java/feign/template/Expressions.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/main/java/feign/template/FormContinuationStyleExpression.java
+++ b/core/src/main/java/feign/template/FormContinuationStyleExpression.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/main/java/feign/template/FormStyleExpression.java
+++ b/core/src/main/java/feign/template/FormStyleExpression.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/main/java/feign/template/FragmentExpression.java
+++ b/core/src/main/java/feign/template/FragmentExpression.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/main/java/feign/template/Literal.java
+++ b/core/src/main/java/feign/template/Literal.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/main/java/feign/template/PathSegmentExpression.java
+++ b/core/src/main/java/feign/template/PathSegmentExpression.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/main/java/feign/template/PathStyleExpression.java
+++ b/core/src/main/java/feign/template/PathStyleExpression.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/main/java/feign/template/ReservedExpression.java
+++ b/core/src/main/java/feign/template/ReservedExpression.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/main/java/feign/template/SimpleExpression.java
+++ b/core/src/main/java/feign/template/SimpleExpression.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/main/java/feign/template/SimpleTemplateParameter.java
+++ b/core/src/main/java/feign/template/SimpleTemplateParameter.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/main/java/feign/template/TemplateParameter.java
+++ b/core/src/main/java/feign/template/TemplateParameter.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/main/java/feign/template/UriTemplate.java
+++ b/core/src/main/java/feign/template/UriTemplate.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/main/java/feign/template/UriUtils.java
+++ b/core/src/main/java/feign/template/UriUtils.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/test/java/feign/FeignTests.java
+++ b/core/src/test/java/feign/FeignTests.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
+import feign.ExceptionHandler.RethrowExceptionHandler;
 import feign.FeignTests.GitHub.Repository;
 import feign.contract.FeignContract;
 import feign.contract.Header;
@@ -29,13 +30,13 @@ import feign.contract.Param;
 import feign.contract.Request;
 import feign.decoder.StringDecoder;
 import feign.encoder.StringEncoder;
-import feign.ExceptionHandler.RethrowExceptionHandler;
 import feign.http.client.UrlConnectionClient;
 import feign.logging.SimpleLogger;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -75,23 +76,31 @@ class FeignTests {
 
     GitHub gitHub = Feign.builder()
         .logger(logger)
-        .decoder(new ResponseDecoder() {
-          @SuppressWarnings("unchecked")
-          @Override
-          public <T> T decode(Response response, Class<T> type) {
-            try {
-              String data = new String(response.toByteArray(), StandardCharsets.UTF_8);
-              return (T) Collections.singletonList(new Repository(data));
-            } catch (IOException ioe) {
-              // ignored
-            }
-            return null;
-          }
-        })
+        .decoder(new GitHubDecoder())
         .target(GitHub.class, "http://localhost:9999");
     assertThat(gitHub).isNotNull();
 
     List<Repository> repositories = gitHub.getRepositories("openfeign");
+    assertThat(repositories).isNotEmpty();
+  }
+
+  @Test
+  void createTarget_andExecuteAsync() throws Exception {
+    Logger logger = SimpleLogger.builder()
+        .setEnabled(true)
+        .setHeadersEnabled(true)
+        .setRequestEnabled(true)
+        .setResponseEnabled(true).build();
+
+    GitHub gitHub = Feign.builder()
+        .logger(logger)
+        .decoder(new GitHubDecoder())
+        .executor(Executors.newFixedThreadPool(10))
+        .target(GitHub.class, "http://localhost:9999");
+    assertThat(gitHub).isNotNull();
+
+    CompletableFuture<List<Repository>> result = gitHub.getRepositoriesAsync("openfeign");
+    List<Repository> repositories = result.get();
     assertThat(repositories).isNotEmpty();
   }
 
@@ -139,6 +148,10 @@ class FeignTests {
     @Headers({@Header(name = "Accept", value = "application/json")})
     List<Repository> getRepositories(@Param("owner") String owner);
 
+    @Request("/users/{owner}/repos")
+    @Headers({@Header(name = "Accept", value = "application/json")})
+    CompletableFuture<List<Repository>> getRepositoriesAsync(@Param("owner") String owner);
+
     void getContributors();
 
     default String getOwner() {
@@ -154,6 +167,20 @@ class FeignTests {
         this.name = name;
       }
 
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  static class GitHubDecoder implements ResponseDecoder {
+
+    @Override
+    public <T> T decode(Response response, Class<T> type) {
+      try {
+        String data = new String(response.toByteArray(), StandardCharsets.UTF_8);
+        return (T) Collections.singletonList(new Repository(data));
+      } catch (IOException ioe) {
+        throw new RuntimeException(ioe.getMessage(), ioe);
+      }
     }
   }
 

--- a/core/src/test/java/feign/TargetMethodDefinitionTest.java
+++ b/core/src/test/java/feign/TargetMethodDefinitionTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign;
 

--- a/core/src/test/java/feign/assertions/AbstractHttpHeaderAssert.java
+++ b/core/src/test/java/feign/assertions/AbstractHttpHeaderAssert.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.assertions;
 

--- a/core/src/test/java/feign/assertions/AbstractHttpRequestAssert.java
+++ b/core/src/test/java/feign/assertions/AbstractHttpRequestAssert.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.assertions;
 

--- a/core/src/test/java/feign/assertions/AbstractHttpResponseAssert.java
+++ b/core/src/test/java/feign/assertions/AbstractHttpResponseAssert.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.assertions;
 

--- a/core/src/test/java/feign/assertions/Assertions.java
+++ b/core/src/test/java/feign/assertions/Assertions.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.assertions;
 

--- a/core/src/test/java/feign/assertions/HttpHeaderAssert.java
+++ b/core/src/test/java/feign/assertions/HttpHeaderAssert.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.assertions;
 

--- a/core/src/test/java/feign/assertions/HttpRequestAssert.java
+++ b/core/src/test/java/feign/assertions/HttpRequestAssert.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.assertions;
 

--- a/core/src/test/java/feign/assertions/HttpResponseAssert.java
+++ b/core/src/test/java/feign/assertions/HttpResponseAssert.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.assertions;
 

--- a/core/src/test/java/feign/contract/FeignContractTest.java
+++ b/core/src/test/java/feign/contract/FeignContractTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.contract;
 
@@ -48,7 +48,7 @@ class FeignContractTest {
     /* verify each method is registered */
     assertThat(methodDefinitions).anyMatch(
         targetMethodDefinition -> targetMethodDefinition.getName().equalsIgnoreCase("get")
-            && targetMethodDefinition.getReturnType() == String.class
+            && targetMethodDefinition.getReturnType().getType() == String.class
             && targetMethodDefinition.getMethod() == HttpMethod.GET
             && targetMethodDefinition.getTemplateParameters().contains(
             new SimpleTemplateParameter("parameter"))
@@ -60,7 +60,7 @@ class FeignContractTest {
     /* implicit body parameter */
     assertThat(methodDefinitions).anyMatch(
         targetMethodDefinition -> targetMethodDefinition.getName().equalsIgnoreCase("post")
-            && targetMethodDefinition.getReturnType() == String.class
+            && targetMethodDefinition.getReturnType().getType() == String.class
             && targetMethodDefinition.getMethod() == HttpMethod.POST
             && targetMethodDefinition.getTemplateParameters().contains(
             new SimpleTemplateParameter("parameter"))
@@ -69,7 +69,7 @@ class FeignContractTest {
     /* explicit body parameter */
     assertThat(methodDefinitions).anyMatch(
         targetMethodDefinition -> targetMethodDefinition.getName().equalsIgnoreCase("put")
-            && targetMethodDefinition.getReturnType() == String.class
+            && targetMethodDefinition.getReturnType().getType() == String.class
             && targetMethodDefinition.getMethod() == HttpMethod.PUT
             && targetMethodDefinition.getTemplateParameters()
             .contains(new SimpleTemplateParameter("parameter"))
@@ -78,7 +78,7 @@ class FeignContractTest {
     /* void return type */
     assertThat(methodDefinitions).anyMatch(
         targetMethodDefinition -> targetMethodDefinition.getName().equalsIgnoreCase("delete")
-            && targetMethodDefinition.getReturnType() == void.class
+            && targetMethodDefinition.getReturnType().getType() == void.class
             && targetMethodDefinition.getMethod() == HttpMethod.DELETE
             && targetMethodDefinition.getTemplateParameters()
             .contains(new SimpleTemplateParameter("parameter"))
@@ -87,7 +87,7 @@ class FeignContractTest {
     /* request options and generic return type */
     assertThat(methodDefinitions).anyMatch(
         targetMethodDefinition -> targetMethodDefinition.getName().equalsIgnoreCase("search")
-            && targetMethodDefinition.getReturnType() == List.class
+            && targetMethodDefinition.getReturnType().getType() == List.class
             && targetMethodDefinition.getMethod() == HttpMethod.GET
             && targetMethodDefinition.getBody() == -1
             && targetMethodDefinition.getConnectTimeout() == 1000

--- a/core/src/test/java/feign/decoder/AbstractResponseDecoderTest.java
+++ b/core/src/test/java/feign/decoder/AbstractResponseDecoderTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.decoder;
 

--- a/core/src/test/java/feign/decoder/StringDecoderTest.java
+++ b/core/src/test/java/feign/decoder/StringDecoderTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.decoder;
 

--- a/core/src/test/java/feign/encoder/StringEncoderTest.java
+++ b/core/src/test/java/feign/encoder/StringEncoderTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.encoder;
 

--- a/core/src/test/java/feign/exception/RethrowExceptionHandlerTest.java
+++ b/core/src/test/java/feign/exception/RethrowExceptionHandlerTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.exception;
 

--- a/core/src/test/java/feign/http/HttpExceptionTest.java
+++ b/core/src/test/java/feign/http/HttpExceptionTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.http;
 

--- a/core/src/test/java/feign/http/HttpHeaderTest.java
+++ b/core/src/test/java/feign/http/HttpHeaderTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.http;
 

--- a/core/src/test/java/feign/http/HttpResponseTest.java
+++ b/core/src/test/java/feign/http/HttpResponseTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.http;
 

--- a/core/src/test/java/feign/http/RequestSpecificationTest.java
+++ b/core/src/test/java/feign/http/RequestSpecificationTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.http;
 

--- a/core/src/test/java/feign/http/client/UrlConnectionClientIntegrationTest.java
+++ b/core/src/test/java/feign/http/client/UrlConnectionClientIntegrationTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.http.client;
 

--- a/core/src/test/java/feign/impl/AbstractTargetMethodHandlerTest.java
+++ b/core/src/test/java/feign/impl/AbstractTargetMethodHandlerTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.impl;
 
@@ -235,7 +235,7 @@ class AbstractTargetMethodHandlerTest {
     assertThrows(IllegalStateException.class,
         () -> targetMethodHandler.execute(Arrays.array("name")));
     verify(this.client, times(1)).request(any(Request.class));
-    verify(this.exceptionHandler, times(2)).accept(any(Throwable.class));
+    verify(this.exceptionHandler, times(1)).accept(any(Throwable.class));
     verifyZeroInteractions(this.decoder);
   }
 

--- a/core/src/test/java/feign/impl/AsyncTargetMethodHandlerTest.java
+++ b/core/src/test/java/feign/impl/AsyncTargetMethodHandlerTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2019 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import feign.Client;
+import feign.Contract;
+import feign.ExceptionHandler;
+import feign.ExceptionHandler.RethrowExceptionHandler;
+import feign.Logger;
+import feign.RequestEncoder;
+import feign.Response;
+import feign.ResponseDecoder;
+import feign.TargetMethodDefinition;
+import feign.contract.FeignContract;
+import feign.contract.Request;
+import feign.impl.AsyncTargetMethodHandlerTest.Blog.Post;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AsyncTargetMethodHandlerTest {
+
+  @Mock
+  private RequestEncoder encoder;
+
+  @Mock
+  private Client client;
+
+  @Mock
+  private ResponseDecoder decoder;
+
+  @Spy
+  private ExceptionHandler exceptionHandler = new RethrowExceptionHandler();
+
+  @Mock
+  private Logger logger;
+
+  @Mock
+  private Response response;
+
+  @Captor
+  private ArgumentCaptor<Class<?>> classArgumentCaptor;
+
+  private Contract contract = new FeignContract();
+
+  private AsyncTargetMethodHandler methodHandler;
+
+  @BeforeEach
+  void setUp() {
+    Collection<TargetMethodDefinition> methodDefinitions =
+        this.contract.apply(new UriTarget<>(Blog.class, "https://www.example.com"));
+    TargetMethodDefinition targetMethodDefinition = methodDefinitions.stream()
+        .findFirst().get();
+    this.methodHandler = new AsyncTargetMethodHandler(
+        targetMethodDefinition,
+        encoder,
+        Collections.emptyList(),
+        client,
+        decoder,
+        exceptionHandler,
+        Executors.newFixedThreadPool(10),
+        logger);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void returnWrappedFuture_onSuccess() throws Exception {
+    when(this.client.request(any(feign.Request.class))).thenReturn(this.response);
+    when(this.decoder.decode(any(Response.class), any())).thenReturn("results");
+    Object result = this.methodHandler.execute(new Object[]{});
+
+    /* ensure that the method handler returned a future, which contains a string */
+    assertThat(result).isInstanceOf(CompletableFuture.class);
+    CompletableFuture<String> future = (CompletableFuture<String>) result;
+    future.get();
+
+    /* capture the call to the decoder, this should be the contained type and not a future */
+    verify(this.decoder).decode(any(Response.class), classArgumentCaptor.capture());
+    assertThat(classArgumentCaptor.getValue()).isAssignableFrom(Post.class);
+    assertThat(future).isCompletedWithValue("results");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void throwException_onFailure() {
+    when(this.client.request(any(feign.Request.class))).thenThrow(new RuntimeException("Failed"));
+    Object result = this.methodHandler.execute(new Object[]{});
+
+    /* ensure that the method handler returned a future, which contains a string */
+    assertThat(result).isInstanceOf(CompletableFuture.class);
+    CompletableFuture<String> future = (CompletableFuture<String>) result;
+    assertThat(future).isCompletedExceptionally();
+    verifyZeroInteractions(this.decoder);
+    verify(this.exceptionHandler, times(1)).accept(any(Throwable.class));
+  }
+
+  interface Blog {
+    @Request(value = "/")
+    CompletableFuture<Post> getPosts();
+
+    class Post {
+
+    }
+  }
+
+}

--- a/core/src/test/java/feign/impl/TypeDrivenMethodHandlerFactoryTest.java
+++ b/core/src/test/java/feign/impl/TypeDrivenMethodHandlerFactoryTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import feign.Client;
+import feign.Contract;
+import feign.ExceptionHandler;
+import feign.FeignConfiguration;
+import feign.Logger;
+import feign.RequestEncoder;
+import feign.ResponseDecoder;
+import feign.Target;
+import feign.TargetMethodDefinition;
+import feign.TargetMethodHandler;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TypeDrivenMethodHandlerFactoryTest {
+
+  private FeignConfiguration feignConfiguration;
+
+  private TargetMethodDefinition targetMethodDefinition;
+
+  private TypeDrivenMethodHandlerFactory methodHandlerFactory;
+
+  @BeforeEach
+  void setUp() {
+    this.feignConfiguration = new BaseFeignConfiguration(
+        mock(Target.class),
+        mock(Contract.class),
+        mock(RequestEncoder.class),
+        Collections.emptyList(),
+        mock(Client.class),
+        mock(ResponseDecoder.class),
+        mock(ExceptionHandler.class),
+        mock(Executor.class),
+        mock(Logger.class));
+
+    this.methodHandlerFactory = new TypeDrivenMethodHandlerFactory();
+  }
+
+  @Test
+  void createsBlockingHandler_byDefault() {
+    this.targetMethodDefinition =
+        new TargetMethodDefinition(new UriTarget<>(Blog.class, "https://www.example.com"));
+    targetMethodDefinition.returnType(String.class);
+    TargetMethodHandler targetMethodHandler =
+        this.methodHandlerFactory.create(this.targetMethodDefinition, this.feignConfiguration);
+    assertThat(targetMethodHandler).isInstanceOf(BlockingTargetMethodHandler.class);
+  }
+
+  @Test
+  void createsAsyncHandler_whenReturnType_isFuture() {
+    this.targetMethodDefinition =
+        new TargetMethodDefinition(new UriTarget<>(Blog.class, "https://www.example.com"));
+    targetMethodDefinition.returnType(Future.class);
+    TargetMethodHandler targetMethodHandler =
+        this.methodHandlerFactory.create(this.targetMethodDefinition, this.feignConfiguration);
+    assertThat(targetMethodHandler).isInstanceOf(AsyncTargetMethodHandler.class);
+  }
+
+  @Test
+  void createsAsyncHandler_whenReturnType_isCompletableFuture() {
+    this.targetMethodDefinition =
+        new TargetMethodDefinition(new UriTarget<>(Blog.class, "https://www.example.com"));
+    targetMethodDefinition.returnType(CompletableFuture.class);
+    TargetMethodHandler targetMethodHandler =
+        this.methodHandlerFactory.create(this.targetMethodDefinition, this.feignConfiguration);
+    assertThat(targetMethodHandler).isInstanceOf(AsyncTargetMethodHandler.class);
+  }
+
+  interface Blog {
+
+  }
+}

--- a/core/src/test/java/feign/impl/UriTargetTest.java
+++ b/core/src/test/java/feign/impl/UriTargetTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.impl;
 

--- a/core/src/test/java/feign/logging/SimpleLoggerTest.java
+++ b/core/src/test/java/feign/logging/SimpleLoggerTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.logging;
 

--- a/core/src/test/java/feign/proxy/ProxyTargetTest.java
+++ b/core/src/test/java/feign/proxy/ProxyTargetTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.proxy;
 

--- a/core/src/test/java/feign/template/DotExpressionTest.java
+++ b/core/src/test/java/feign/template/DotExpressionTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/test/java/feign/template/ExpressionTest.java
+++ b/core/src/test/java/feign/template/ExpressionTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/test/java/feign/template/ExpressionsTest.java
+++ b/core/src/test/java/feign/template/ExpressionsTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/test/java/feign/template/FormContinuationStyleExpressionTest.java
+++ b/core/src/test/java/feign/template/FormContinuationStyleExpressionTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/test/java/feign/template/FormStyleExpressionTest.java
+++ b/core/src/test/java/feign/template/FormStyleExpressionTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/test/java/feign/template/FragmentExpressionTest.java
+++ b/core/src/test/java/feign/template/FragmentExpressionTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/test/java/feign/template/PathSegmentExpressionTest.java
+++ b/core/src/test/java/feign/template/PathSegmentExpressionTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/test/java/feign/template/PathStyleExpressionTest.java
+++ b/core/src/test/java/feign/template/PathStyleExpressionTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/test/java/feign/template/ReservedExpressionTest.java
+++ b/core/src/test/java/feign/template/ReservedExpressionTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/test/java/feign/template/SimpleExpressionTest.java
+++ b/core/src/test/java/feign/template/SimpleExpressionTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/test/java/feign/template/StyleExpressionTest.java
+++ b/core/src/test/java/feign/template/StyleExpressionTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/test/java/feign/template/UriTemplateTckTests.java
+++ b/core/src/test/java/feign/template/UriTemplateTckTests.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/test/java/feign/template/UriTemplateTest.java
+++ b/core/src/test/java/feign/template/UriTemplateTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/test/java/feign/template/UriUtilsTest.java
+++ b/core/src/test/java/feign/template/UriUtilsTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template;
 

--- a/core/src/test/java/feign/template/tck/TestCase.java
+++ b/core/src/test/java/feign/template/tck/TestCase.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template.tck;
 

--- a/core/src/test/java/feign/template/tck/TestExamples.java
+++ b/core/src/test/java/feign/template/tck/TestExamples.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template.tck;
 

--- a/core/src/test/java/feign/template/tck/TestGroup.java
+++ b/core/src/test/java/feign/template/tck/TestGroup.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package feign.template.tck;
 

--- a/src/resources/header-definition.xml
+++ b/src/resources/header-definition.xml
@@ -3,7 +3,7 @@
   <javadoc_style>
     <firstLine>/*</firstLine>
     <beforeEachLine> * </beforeEachLine>
-    <endLine>*/EOL</endLine>
+    <endLine> */EOL</endLine>
     <allowBlankLines>true</allowBlankLines>
     <firstLineDetectionPattern>(\s|\t)*/\*.*$</firstLineDetectionPattern>
     <lastLineDetectionPattern>.*\*/(\s|\t)*$</lastLineDetectionPattern>


### PR DESCRIPTION
Fixes #18

Adding a new TargetMethodHandler that wraps the Future being executed
on the Executor in a CompleteableFuture.  This method handler will be
used when the target interface defines a method that returns either a
Future or CompleteableFuture.

Decoding of Future objects is not as straight forward as it is with
regular types, since the Future is a container for a result.  The
TypeDefinitions have been updated to identify when one of these
'container' types are desired and will decode the contained type instead.

Additional Changes include:
* Adding Test Cases
* License Formatting.