### PR TITLE
Replace RunnableFuture with CompletableFuture

### DIFF
--- a/core/src/main/java/feign/impl/AbstractTargetMethodHandler.java
+++ b/core/src/main/java/feign/impl/AbstractTargetMethodHandler.java
@@ -145,15 +145,6 @@ public abstract class AbstractTargetMethodHandler implements TargetMethodHandler
   }
 
   /**
-   * The Executor for this method.
-   *
-   * @return the executor defined.
-   */
-  protected Executor getExecutor() {
-    return this.executor;
-  }
-
-  /**
    * The Exception Handler defined.
    *
    * @return the exception handler.

--- a/core/src/main/java/feign/impl/BlockingTargetMethodHandler.java
+++ b/core/src/main/java/feign/impl/BlockingTargetMethodHandler.java
@@ -25,6 +25,7 @@ import feign.Response;
 import feign.ResponseDecoder;
 import feign.TargetMethodDefinition;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RunnableFuture;
 
@@ -61,7 +62,7 @@ public class BlockingTargetMethodHandler extends AbstractTargetMethodHandler {
    * @throws Exception if the response could not be processed.
    */
   @Override
-  protected Object handleResponse(RunnableFuture<Response> request) throws Exception {
+  protected Object handleResponse(CompletableFuture<Response> request) throws Exception {
 
     /* pull the result of the task immediately, waiting for it to complete */
     log.debug("Waiting for the Response.");

--- a/core/src/test/java/feign/impl/UriTargetTest.java
+++ b/core/src/test/java/feign/impl/UriTargetTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import feign.Target;
+import feign.http.RequestSpecification;
+import java.net.URI;
 import org.junit.jupiter.api.Test;
 
 class UriTargetTest {
@@ -54,5 +56,13 @@ class UriTargetTest {
     Target<?> one = new UriTarget<>(String.class, "https://www.example.com");
     Target<?> two = new UriTarget<>(String.class, "another", "https://www.example.com");
     assertThat(one).isNotEqualTo(two);
+  }
+
+  @Test
+  void requestSpecification_mustNotContainAbsoluteUri() {
+    Target<?> target = new UriTarget<>(String.class, "Sample", "https://www.example.com");
+    RequestSpecification requestSpecification = new RequestSpecification();
+    requestSpecification.uri(URI.create("https://wwww.example.com"));
+    assertThrows(IllegalStateException.class, () -> target.apply(requestSpecification));
   }
 }


### PR DESCRIPTION
Async implementation did not need to wrap the runnable future when
`CompletableFuture` performs the same function.  Refactored the code
accordingly.

Adding Test Coverage.