### PR TITLE
Refactor AbstractTargetMethodHander to be async by default

### DIFF
--- a/core/src/main/java/feign/Client.java
+++ b/core/src/main/java/feign/Client.java
@@ -17,7 +17,6 @@
 package feign;
 
 import feign.exception.FeignException;
-import feign.http.HttpException;
 
 /**
  * Target Client instance responsible for submitting the Request to the Target and processing

--- a/core/src/main/java/feign/http/HttpException.java
+++ b/core/src/main/java/feign/http/HttpException.java
@@ -17,7 +17,6 @@
 package feign.http;
 
 import feign.Client;
-import feign.Request;
 import java.util.Optional;
 
 /**

--- a/core/src/main/java/feign/http/HttpHeader.java
+++ b/core/src/main/java/feign/http/HttpHeader.java
@@ -25,7 +25,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Predicate;
 
 /**
  * Header implementation for Http Requests.

--- a/core/src/main/java/feign/impl/AbstractTargetMethodHandler.java
+++ b/core/src/main/java/feign/impl/AbstractTargetMethodHandler.java
@@ -18,6 +18,7 @@ package feign.impl;
 
 import feign.Client;
 import feign.ExceptionHandler;
+import feign.Logger;
 import feign.Request;
 import feign.RequestEncoder;
 import feign.RequestInterceptor;
@@ -37,7 +38,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -48,15 +48,15 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("WeakerAccess")
 public abstract class AbstractTargetMethodHandler implements TargetMethodHandler {
 
-  protected final Logger log = LoggerFactory.getLogger(this.getClass());
-  private TargetMethodDefinition targetMethodDefinition;
+  protected final org.slf4j.Logger log = LoggerFactory.getLogger(this.getClass());
+  protected TargetMethodDefinition targetMethodDefinition;
   private RequestEncoder encoder;
   private List<RequestInterceptor> interceptors;
   private Client client;
   private ResponseDecoder decoder;
   private ExceptionHandler exceptionHandler;
+  private Logger logger;
   private Executor executor;
-  private feign.Logger logger;
 
   /**
    * Creates a new Abstract Target HttpMethod Handler.
@@ -67,7 +67,7 @@ public abstract class AbstractTargetMethodHandler implements TargetMethodHandler
    * @param client to send the request and create the response.
    * @param decoder to use when parsing the response.
    * @param exceptionHandler to delegate to when an exception occurs.
-   * @param executor to execute the request on.
+   * @param executor to request the request on.
    * @param logger for logging requests and responses.
    */
   protected AbstractTargetMethodHandler(
@@ -97,58 +97,61 @@ public abstract class AbstractTargetMethodHandler implements TargetMethodHandler
    * @return the result of the request.
    */
   @Override
-  public Object execute(Object[] arguments) {
+  public Object execute(final Object[] arguments) {
 
-    try {
-      /* prepare the request specification */
-      final RequestSpecification requestSpecification = this.resolve(arguments);
+    /* prepare the request specification */
+    final RequestSpecification requestSpecification = this.resolve(arguments);
 
-      /* apply any interceptors */
-      this.intercept(requestSpecification);
+    /* create an asynchronous chain, using the provided executor.  this implementation
+     * is not non-blocking, however, it does try to take advantage of the executor provided.
+     *
+     * if the default executor is used, each one of these steps will be executed on the calling
+     * thread and not on a different pool or on the default fork-join common pool, making
+     * this call effectively synchronous.
+     */
+    CompletableFuture<Object> result =
+        CompletableFuture.runAsync(() -> intercept(requestSpecification), this.executor)
+            .thenRunAsync(() -> encode(requestSpecification, arguments), this.executor)
+            .thenApplyAsync(nothing -> requestSpecification.build(), this.executor)
+            .thenApplyAsync(this::request, this.executor)
+            .handleAsync((response, throwable) -> {
+              if (throwable != null) {
+                /* dispatch to the error handler */
+                log.error("Error occurred during method processing.  "
+                        + "Passing to Exception Handler.  Exception: {}: {}",
+                    throwable.getClass().getSimpleName(), throwable.getMessage());
+                exceptionHandler.accept(throwable);
+              } else {
+                try {
+                  /* decode the response */
+                  return decode(response);
+                } catch (Exception ex) {
+                  log.error("Error occurred processing the response.  Passing to Exception Handler."
+                      + "  Exception: {} {}", ex.getClass().getSimpleName(), ex.getMessage());
+                  exceptionHandler.accept(ex);
+                }
+              }
+              log.warn(
+                  "All Methods are expected to either return a value or throw an Exception.  "
+                      + "This method did not provide either.  This means either that the value "
+                      + "of the method should be 'void' or that the Exception Handler did not "
+                      + "properly generate an exception.  Please review your target, method "
+                      + "definition, and exception handler.");
+              throw new IllegalStateException("Error occurred when trying to request the request "
+                  + "and either no Response was returned or an Exception was left unhandled.");
+            }, this.executor);
 
-      /* encode the request */
-      Object body =
-          (this.targetMethodDefinition.getBody() != -1) ? arguments[this.targetMethodDefinition
-              .getBody()] : null;
-      this.encode(requestSpecification, body);
-
-      /* execute the request on the provided executor */
-      final Request request = requestSpecification.build();
-      CompletableFuture<Response> task = this.getTask(request);
-
-      /* process the results of the task */
-      return this.handleResponse(task);
-
-    } catch (Exception ex) {
-      log.error("Error occurred during method processing.  "
-              + "Passing to Exception Handler.  Exception: {}: {}",
-          ex.getClass().getSimpleName(), ex.getMessage());
-      this.exceptionHandler.accept(
-          new FeignException(
-              "Error occurred during method processing", ex, targetMethodDefinition.getTag()));
-    }
-
-    /* method was not handled properly */
-    throw methodNotHandled();
-  }
-
-  /**
-   * The Exception Handler defined.
-   *
-   * @return the exception handler.
-   */
-  protected ExceptionHandler getExceptionHandler() {
-    return this.exceptionHandler;
+    /* delegate any additional handling to the sub classes. */
+    return this.handleResponse(result);
   }
 
   /**
    * Process the results of the HttpRequest.
    *
-   * @param response Future containing the results of the request.
+   * @param result Future containing the results of the request.
    * @return the result of the request, decoded if necessary.
-   * @throws Exception in the event the response could not be processed.
    */
-  protected abstract Object handleResponse(CompletableFuture<Response> response) throws Exception;
+  protected abstract Object handleResponse(CompletableFuture<Object> result);
 
   /**
    * Resolve any parameters and variables for this Request.
@@ -177,16 +180,43 @@ public abstract class AbstractTargetMethodHandler implements TargetMethodHandler
   }
 
   /**
+   * Determines which method argument contains the Request body, if any.
+   *
+   * @param arguments for the method.
+   * @return the object to use as the request body, if any.
+   */
+  protected Optional<Object> getRequestBody(Object[] arguments) {
+    Object body =
+        (this.targetMethodDefinition.getBody() != -1) ? arguments[this.targetMethodDefinition
+            .getBody()] : null;
+    return Optional.ofNullable(body);
+  }
+
+  /**
    * Encode the Request Body, if required.
    *
    * @param requestSpecification to receive the encoded result.
-   * @param body to encode, can be {@literal null}.
+   * @param arguments that may contain the request body.
    */
-  protected void encode(RequestSpecification requestSpecification, Object body) {
-    if (body != null) {
-      log.debug("Encoding Request Body: {}", body.getClass().getSimpleName());
-      this.encoder.apply(body, requestSpecification);
-    }
+  protected void encode(RequestSpecification requestSpecification, Object[] arguments) {
+    this.getRequestBody(arguments)
+        .ifPresent(body -> {
+          log.debug("Encoding Request Body: {}", body.getClass().getSimpleName());
+          this.encoder.apply(body, requestSpecification);
+        });
+  }
+
+  /**
+   * Execute the Request on the Executor.
+   *
+   * @param request to request.
+   * @return a {@link CompletableFuture} containing the Response.
+   */
+  protected Response request(final Request request) {
+    this.logRequest(targetMethodDefinition.getTag(), request);
+    final Response response = client.request(request);
+    this.logResponse(targetMethodDefinition.getTag(), response);
+    return response;
   }
 
   /**
@@ -194,19 +224,24 @@ public abstract class AbstractTargetMethodHandler implements TargetMethodHandler
    *
    * @param response to decode.
    * @return the desired decoded result
-   * @throws feign.exception.FeignException if the response could not be decoded.
    */
   protected Object decode(Response response) {
     TypeDefinition typeDefinition = targetMethodDefinition.getReturnType();
     Class<?> returnType = typeDefinition.getType();
-    if (Response.class == returnType) {
+    if (void.class == returnType || (response == null || response.body() == null)) {
+      return null;
+    } else if (Response.class == returnType) {
       /* no need to decode */
       log.debug("Response type is feign.Response, no decoding necessary.");
       return response;
     } else {
-      /* decode the response */
-      log.debug("Decoding Response: {}", response);
-      return this.decode(response, typeDefinition);
+      try {
+        /* decode the response */
+        log.debug("Decoding Response: {}", response);
+        return this.decode(response, typeDefinition);
+      } catch (Exception ex) {
+        throw new FeignException(ex.getMessage(), ex, this.targetMethodDefinition.getTag());
+      }
     }
   }
 
@@ -216,17 +251,22 @@ public abstract class AbstractTargetMethodHandler implements TargetMethodHandler
    * @param response to decode.
    * @param typeDefinition to use to determine what the resulting type should be.
    * @return the response body decoded into the desired type.
+   * @throws Exception if the {@link Response} cannot be closed after decoding.
    */
-  private Object decode(Response response, TypeDefinition typeDefinition) {
+  private Object decode(Response response, TypeDefinition typeDefinition) throws Exception {
     /* before jumping into and just passing the raw type the decoder, there are
      * certain types that act as containers.  when decoding these types, we want to
      * decode the 'contained' type and then wrap the result in the desired container,
      */
-    if (typeDefinition.isContainer()) {
-      /* we want to decode the actual type */
-      return this.decoder.decode(response, typeDefinition.getActualType());
-    } else {
-      return this.decoder.decode(response, typeDefinition.getType());
+    try {
+      if (typeDefinition.isContainer()) {
+        /* we want to decode the actual type */
+        return this.decoder.decode(response, typeDefinition.getActualType());
+      } else {
+        return this.decoder.decode(response, typeDefinition.getType());
+      }
+    } finally {
+      response.close();
     }
   }
 
@@ -245,38 +285,6 @@ public abstract class AbstractTargetMethodHandler implements TargetMethodHandler
       templateParameter.ifPresent(parameter -> variables.put(parameter.name(), argument));
     }
     return variables;
-  }
-
-  /**
-   * Creates a new {@link CompletableFuture} wrapping the {@link Client}, running on the executor
-   * provided.
-   *
-   * @param request to send.
-   * @return a Future containing the result of the request.
-   * @throws IllegalStateException if the task could not be handled properly.
-   */
-  private CompletableFuture<Response> getTask(final Request request) {
-    return CompletableFuture.supplyAsync(() -> {
-      this.logRequest(targetMethodDefinition.getTag(), request);
-      final Response response = client.request(request);
-      this.logResponse(targetMethodDefinition.getTag(), response);
-      return response;
-    }, this.executor);
-  }
-
-  /**
-   * Creates a new Illegal State Exception in the event that either the task or the method
-   * invocation was not handled correctly.
-   *
-   * @return a RuntimeException describing the illegal state.
-   */
-  private RuntimeException methodNotHandled() {
-    log.warn("All Methods are expected to either return a value or throw an Exception.  "
-        + "This method did not provide either.  This means either that the value of the method "
-        + "should be 'void' or that the Exception Handler did not properly generate an exception.  "
-        + "Please review your target, method definition, and exception handler.");
-    return new IllegalStateException("Error occurred when trying to execute the request "
-        + "and either no Response was returned or an Exception was left unhandled.");
   }
 
   /**

--- a/core/src/main/java/feign/impl/AsyncTargetMethodHandler.java
+++ b/core/src/main/java/feign/impl/AsyncTargetMethodHandler.java
@@ -21,7 +21,6 @@ import feign.ExceptionHandler;
 import feign.Logger;
 import feign.RequestEncoder;
 import feign.RequestInterceptor;
-import feign.Response;
 import feign.ResponseDecoder;
 import feign.TargetMethodDefinition;
 import java.util.List;
@@ -43,7 +42,7 @@ public class AsyncTargetMethodHandler extends AbstractTargetMethodHandler {
    * @param client to send the request and create the response.
    * @param decoder to use when parsing the response.
    * @param exceptionHandler to delegate to when an exception occurs.
-   * @param executor to execute the request on.
+   * @param executor to request the request on.
    * @param logger for logging requests and responses.
    */
   AsyncTargetMethodHandler(TargetMethodDefinition targetMethodDefinition,
@@ -59,20 +58,12 @@ public class AsyncTargetMethodHandler extends AbstractTargetMethodHandler {
    * CompletableFuture} containing the decoded Response body.  The method handler's Executor is used
    * for this future.
    *
-   * @param response Future containing the results of the request.
+   * @param result Future containing the results of the request.
    * @return a {@link CompletableFuture} reference wrapping the results.
    */
   @Override
-  protected Object handleResponse(CompletableFuture<Response> response) {
-    /* handle the result of the future */
-    return response.handle((resp, throwable) -> {
-      if (throwable != null) {
-        /* invoke the exception handler here, as it will not be thrown to the parent. */
-        getExceptionHandler().accept(throwable);
-      } else {
-        return decode(resp);
-      }
-      return null;
-    });
+  protected Object handleResponse(CompletableFuture<Object> result) {
+    /* let the caller decide what to do with it */
+    return result;
   }
 }

--- a/core/src/main/java/feign/impl/type/AbstractTypeDefinition.java
+++ b/core/src/main/java/feign/impl/type/AbstractTypeDefinition.java
@@ -18,7 +18,6 @@ package feign.impl.type;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
-import java.util.Optional;
 import java.util.concurrent.Future;
 
 /**

--- a/core/src/main/java/feign/logging/AbstractLogger.java
+++ b/core/src/main/java/feign/logging/AbstractLogger.java
@@ -24,6 +24,10 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.StringJoiner;
 
+/**
+ * Base Logger implementation.
+ */
+@SuppressWarnings("WeakerAccess")
 public abstract class AbstractLogger implements Logger {
 
   private final boolean enabled;
@@ -31,6 +35,14 @@ public abstract class AbstractLogger implements Logger {
   private final boolean responseEnabled;
   private final boolean headersEnabled;
 
+  /**
+   * Creates a new Abstract Logger.
+   *
+   * @param enabled flag.
+   * @param requestEnabled flag.
+   * @param responseEnabled flag.
+   * @param headersEnabled flag.
+   */
   protected AbstractLogger(boolean enabled, boolean requestEnabled, boolean responseEnabled,
       boolean headersEnabled) {
     this.enabled = enabled;
@@ -111,7 +123,7 @@ public abstract class AbstractLogger implements Logger {
 
   }
 
-  protected void logHeader(Header header, StringJoiner joiner) {
+  private void logHeader(Header header, StringJoiner joiner) {
     joiner.add(header.name() + "=" + header.values());
   }
 

--- a/core/src/main/java/feign/template/Expression.java
+++ b/core/src/main/java/feign/template/Expression.java
@@ -277,7 +277,7 @@ public abstract class Expression implements Chunk {
    * @param builder to append to.
    * @param delimiter to append.
    */
-  protected void appendDelimiter(StringBuilder builder, String delimiter) {
+  void appendDelimiter(StringBuilder builder, String delimiter) {
     if (builder.length() != 0) {
       /* only append if values are already present */
       builder.append(delimiter);
@@ -291,7 +291,7 @@ public abstract class Expression implements Chunk {
    * @param result value.
    * @param builder to append the named result to.
    */
-  protected void appendNamedResult(String name, Object result, StringBuilder builder) {
+  void appendNamedResult(String name, Object result, StringBuilder builder) {
     /* prepend the name */
     builder.append(this.encode(name))
         .append("=")

--- a/core/src/main/java/feign/template/ReservedExpression.java
+++ b/core/src/main/java/feign/template/ReservedExpression.java
@@ -30,8 +30,4 @@ public class ReservedExpression extends SimpleExpression {
     return super.isCharacterAllowed(character) || UriUtils.isReserved(character);
   }
 
-  @Override
-  protected String getPrefix() {
-    return super.getPrefix();
-  }
 }

--- a/core/src/main/java/feign/template/UriTemplate.java
+++ b/core/src/main/java/feign/template/UriTemplate.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**

--- a/core/src/test/java/feign/impl/AsyncTargetMethodHandlerTest.java
+++ b/core/src/test/java/feign/impl/AsyncTargetMethodHandlerTest.java
@@ -34,13 +34,17 @@ import feign.RequestEncoder;
 import feign.Response;
 import feign.ResponseDecoder;
 import feign.TargetMethodDefinition;
+import feign.TargetMethodHandler;
 import feign.contract.FeignContract;
 import feign.contract.Request;
 import feign.impl.AsyncTargetMethodHandlerTest.Blog.Post;
+import feign.support.AuditingExecutor;
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -79,6 +83,8 @@ class AsyncTargetMethodHandlerTest {
 
   private AsyncTargetMethodHandler methodHandler;
 
+  private Executor executor = Executors.newFixedThreadPool(10);
+
   @BeforeEach
   void setUp() {
     Collection<TargetMethodDefinition> methodDefinitions =
@@ -92,7 +98,7 @@ class AsyncTargetMethodHandlerTest {
         client,
         decoder,
         exceptionHandler,
-        Executors.newFixedThreadPool(10),
+        this.executor,
         logger);
   }
 
@@ -100,6 +106,7 @@ class AsyncTargetMethodHandlerTest {
   @Test
   void returnWrappedFuture_onSuccess() throws Exception {
     when(this.client.request(any(feign.Request.class))).thenReturn(this.response);
+    when(this.response.body()).thenReturn(mock(InputStream.class));
     when(this.decoder.decode(any(Response.class), any())).thenReturn("results");
     Object result = this.methodHandler.execute(new Object[]{});
 
@@ -116,7 +123,7 @@ class AsyncTargetMethodHandlerTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  void throwException_onFailure() throws Exception {
+  void throwException_onFailure() {
     when(this.client.request(any(feign.Request.class))).thenThrow(new RuntimeException("Failed"));
     Object result = this.methodHandler.execute(new Object[]{});
 
@@ -132,7 +139,7 @@ class AsyncTargetMethodHandlerTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  void methodNotHandled_returnsNull() throws Exception {
+  void methodNotHandled_returnsNull() {
     Collection<TargetMethodDefinition> methodDefinitions =
         this.contract.apply(new UriTarget<>(Blog.class, "https://www.example.com"));
     TargetMethodDefinition targetMethodDefinition = methodDefinitions.stream()
@@ -154,12 +161,36 @@ class AsyncTargetMethodHandlerTest {
     /* ensure that the method handler returned a future, which contains a string */
     assertThat(result).isInstanceOf(CompletableFuture.class);
     CompletableFuture<String> future = (CompletableFuture<String>) result;
-    future.get();
+    assertThrows(ExecutionException.class, future::get);
 
-    assertThat(future).isCompleted();
-    assertThat(future).isCompletedWithValue(null);
+    assertThat(future).isCompletedExceptionally();
     verifyZeroInteractions(this.decoder);
     verify(mockHandler, times(1)).accept(any(Throwable.class));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void usingMultiThreadedExecutor_willExecuteOnOtherThreads() throws Throwable {
+    AuditingExecutor executor = new AuditingExecutor(this.executor);
+    Collection<TargetMethodDefinition> methodDefinitions =
+        this.contract.apply(new UriTarget<>(Blog.class, "https://www.example.com"));
+    TargetMethodDefinition targetMethodDefinition = methodDefinitions.stream()
+        .findFirst().get();
+    TargetMethodHandler asyncTargetMethodHandler = new AsyncTargetMethodHandler(targetMethodDefinition, encoder,
+        Collections.emptyList(), client, decoder, exceptionHandler, executor, logger);
+
+    /* get the current thread id */
+    long currentThread = Thread.currentThread().getId();
+
+    /* execute the request */
+    CompletableFuture<Object> result =
+        (CompletableFuture) asyncTargetMethodHandler.execute(new Object[]{});
+    result.get();
+
+    /* make sure that the executor used different threads */
+    assertThat(executor.getThreads()).doesNotHaveDuplicates()
+        .hasSizeGreaterThan(1).contains(currentThread);
+    assertThat(executor.getExecutionCount()).isEqualTo(5);
   }
 
   interface Blog {

--- a/core/src/test/java/feign/impl/BlockingTargetMethodHandlerTest.java
+++ b/core/src/test/java/feign/impl/BlockingTargetMethodHandlerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import feign.Client;
+import feign.ExceptionHandler;
+import feign.Logger;
+import feign.RequestEncoder;
+import feign.ResponseDecoder;
+import feign.TargetMethodDefinition;
+import feign.TargetMethodHandler;
+import feign.contract.Request;
+import feign.http.HttpMethod;
+import feign.support.AuditingExecutor;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BlockingTargetMethodHandlerTest {
+
+  @Mock
+  private RequestEncoder encoder;
+
+  @Mock
+  private Client client;
+
+  @Mock
+  private ResponseDecoder decoder;
+
+  @Mock
+  private ExceptionHandler exceptionHandler;
+
+  @Mock
+  private Logger logger;
+
+  @Test
+  void usingDefaultExecutor_willUseTheCallingThread() throws Throwable {
+    AuditingExecutor executor = new AuditingExecutor();
+    TargetMethodDefinition methodDefinition = new TargetMethodDefinition(
+        new UriTarget<>(Blog.class, "https://www.example.com"));
+    TargetMethodHandler blockingHandler = new BlockingTargetMethodHandler(methodDefinition, encoder,
+        Collections.emptyList(), client, decoder, exceptionHandler, executor, logger);
+
+    methodDefinition.returnType(void.class)
+        .uri("/resources/{name}")
+        .method(HttpMethod.GET);
+
+    /* get the current thread id */
+    long currentThread = Thread.currentThread().getId();
+
+    /* execute the request */
+    blockingHandler.execute(new Object[]{});
+
+    /* make sure that the executor used the current thread only */
+    assertThat(executor.getThreads()).containsOnly(currentThread);
+    assertThat(executor.getExecutionCount()).isEqualTo(5);
+  }
+
+  interface Blog {
+
+    @Request(value = "/")
+    Post getPosts();
+
+    class Post {
+
+    }
+  }
+}

--- a/core/src/test/java/feign/support/AuditingExecutor.java
+++ b/core/src/test/java/feign/support/AuditingExecutor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.support;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class AuditingExecutor implements Executor {
+
+  private Set<Long> threads = new HashSet<>();
+  private AtomicInteger executionCount = new AtomicInteger();
+  private Executor delegate;
+
+  public AuditingExecutor() {
+    super();
+  }
+
+  public AuditingExecutor(Executor delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    executionCount.incrementAndGet();
+    this.threads.add(Thread.currentThread().getId());
+
+    /* run on the current thread */
+    if (delegate != null) {
+      delegate.execute(command);
+    } else {
+      command.run();
+    }
+  }
+
+  public Set<Long> getThreads() {
+    return this.threads;
+  }
+
+  public int getExecutionCount() {
+    return this.executionCount.intValue();
+  }
+}


### PR DESCRIPTION
Refactored `AbstractTargetMethodHandler` to use a `CompletableFuture` chain instead of imperative function calls to simplify async processing.  This change has no effect on processing unless the Executor specified is backed by a thread pool of some sort, as the default executor uses the calling thread to execute all Future's.

Additional Changes:
* processing functions have been made `protected`, to allow for easier extension.
* exception handlers are now triggered on decode errors.
* code clean up.