### PR TITLE
Adding Expander Registry

### DIFF
--- a/core/src/main/java/feign/contract/Param.java
+++ b/core/src/main/java/feign/contract/Param.java
@@ -16,6 +16,8 @@
 
 package feign.contract;
 
+import feign.template.ExpressionExpander;
+import feign.template.expander.DefaultExpander;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -37,4 +39,10 @@ public @interface Param {
    */
   String value();
 
+  /**
+   * Expander instance to use.
+   *
+   * @return the expression expander type.
+   */
+  Class<? extends ExpressionExpander> expander() default DefaultExpander.class;
 }

--- a/core/src/main/java/feign/template/ExpanderRegistry.java
+++ b/core/src/main/java/feign/template/ExpanderRegistry.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.template;
+
+/**
+ * Factory for creating {@link ExpressionExpander} instances.
+ */
+public interface ExpanderRegistry {
+
+  /**
+   * Retrieves an {@link ExpressionExpander} based on the type.
+   *
+   * @param type of the value to be expanded.
+   * @return an {@link ExpressionExpander} instance.
+   * @throws IllegalStateException if the expander instance could not be created.
+   */
+  ExpressionExpander getExpanderByType(Class<?> type);
+
+  /**
+   * Retrieves an {@link ExpressionExpander} instance from the expander type provided.
+   *
+   * @param expanderClass to retrieve.
+   * @return an {@link ExpressionExpander} instance of the type provided.
+   * @throws IllegalStateException if the expander instance could be created.
+   */
+  ExpressionExpander getExpander(Class<? extends ExpressionExpander> expanderClass);
+}

--- a/core/src/main/java/feign/template/expander/CachingExpanderRegistry.java
+++ b/core/src/main/java/feign/template/expander/CachingExpanderRegistry.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.template.expander;
+
+import feign.template.ExpanderRegistry;
+import feign.template.ExpressionExpander;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Expander Registry that caches {@link ExpressionExpander} instances and reuses them.
+ */
+public class CachingExpanderRegistry implements ExpanderRegistry {
+
+  private final Map<Class<?>, ExpressionExpander> expanderMapCache = new ConcurrentHashMap<>();
+
+  /**
+   * Retrieves the {@link ExpressionExpander} registered for the specified type.  In the event
+   * that there is no expander registered, a new expander will be created and returned.
+   *
+   * @param parameterType to be expanded.
+   * @return an {@link ExpressionExpander} instance.
+   */
+  @Override
+  public ExpressionExpander getExpanderByType(Class<?> parameterType) {
+    /* uses singleton instances for our internal expander instances */
+    return this.expanderMapCache.computeIfAbsent(parameterType,
+        type -> {
+          if (Iterable.class.isAssignableFrom(parameterType)) {
+            return ListExpander.getInstance();
+          } else if (Map.class.isAssignableFrom(parameterType)) {
+            return MapExpander.getInstance();
+          } else {
+            return SimpleExpander.getInstance();
+          }
+        });
+  }
+
+  /**
+   * Retrieve the {@link ExpressionExpander} instance for the specified custom
+   * {@link ExpressionExpander} type specified.  If no instance exists, a new instance will be
+   * created and cached.
+   *
+   * @param expanderClass to retrieve.
+   * @return an instance of the provided expander.
+   */
+  @Override
+  public ExpressionExpander getExpander(Class<? extends ExpressionExpander> expanderClass) {
+    return this.expanderMapCache.computeIfAbsent(expanderClass,
+        type -> {
+          try {
+            return (ExpressionExpander) type.getDeclaredConstructor().newInstance();
+          } catch (Exception ex) {
+            throw new IllegalStateException("Error occurred creating custom expander instance "
+                + "for type " + type.getSimpleName() + ".  "
+                + "Could not create instance." + ex.getMessage(), ex);
+          }
+        });
+  }
+}

--- a/core/src/main/java/feign/template/expander/DefaultExpander.java
+++ b/core/src/main/java/feign/template/expander/DefaultExpander.java
@@ -14,22 +14,15 @@
  * limitations under the License.
  */
 
-package feign.template;
+package feign.template.expander;
 
-/**
- * Manages the expansion of a given Expression.  Implementations are expected to provide a
- * default, no-argument constructor and be thread-safe, to encourage lazy initialization and reuse
- * between {@link feign.Target}s.
- */
-public interface ExpressionExpander {
+import feign.template.ExpressionExpander;
+import feign.template.ExpressionVariable;
 
-  /**
-   * Expand the given expression, using the value provided.
-   *
-   * @param variable to expand.
-   * @param value containing the variable values.
-   * @return the expanded result, an empty string, or {@literal null}.
-   */
-  String expand(ExpressionVariable variable, Object value);
+public class DefaultExpander implements ExpressionExpander {
 
+  @Override
+  public String expand(ExpressionVariable variable, Object value) {
+    throw new UnsupportedOperationException("expansion is not supported.");
+  }
 }

--- a/core/src/main/java/feign/template/expander/ListExpander.java
+++ b/core/src/main/java/feign/template/expander/ListExpander.java
@@ -25,6 +25,13 @@ import feign.template.ExpressionVariable;
  */
 public class ListExpander extends SimpleExpander {
 
+  /* Singleton instantiation */
+  private static final ListExpander instance = new ListExpander();
+
+  public static ListExpander getInstance() {
+    return instance;
+  }
+
   @Override
   public String expand(ExpressionVariable variable, Object value) {
 

--- a/core/src/main/java/feign/template/expander/MapExpander.java
+++ b/core/src/main/java/feign/template/expander/MapExpander.java
@@ -27,6 +27,13 @@ import java.util.Map;
  */
 public class MapExpander extends SimpleExpander {
 
+  /* Singleton instantiation */
+  private static final MapExpander instance = new MapExpander();
+
+  public static MapExpander getInstance() {
+    return instance;
+  }
+
   @Override
   public String expand(ExpressionVariable variable, Object value) {
 

--- a/core/src/main/java/feign/template/expander/SimpleExpander.java
+++ b/core/src/main/java/feign/template/expander/SimpleExpander.java
@@ -31,6 +31,13 @@ import java.nio.charset.StandardCharsets;
  */
 public class SimpleExpander implements ExpressionExpander {
 
+  /* Singleton instantiation */
+  private static final SimpleExpander instance = new SimpleExpander();
+
+  public static SimpleExpander getInstance() {
+    return instance;
+  }
+
   @Override
   public String expand(ExpressionVariable variable, Object value) {
 

--- a/core/src/test/java/feign/template/expander/CachingExpanderRegistryTest.java
+++ b/core/src/test/java/feign/template/expander/CachingExpanderRegistryTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.template.expander;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import feign.support.Assert;
+import feign.template.ExpressionExpander;
+import feign.template.ExpressionVariable;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CachingExpanderRegistryTest {
+
+  private CachingExpanderRegistry expanderRegistry = new CachingExpanderRegistry();
+
+  @Test
+  void map_shouldBeExpandedWith_MapExpander() {
+    assertThat(this.expanderRegistry.getExpanderByType(Map.class)).isInstanceOf(MapExpander.class);
+  }
+
+  @Test
+  void list_shouldBeExpandedWith_ListExpander() {
+    assertThat(this.expanderRegistry.getExpanderByType(List.class))
+        .isInstanceOf(ListExpander.class);
+  }
+
+  @Test
+  void simpleTypes_shouldBeExpandedWith_SimpleExpander() {
+    assertThat(this.expanderRegistry.getExpanderByType(String.class))
+        .isInstanceOf(SimpleExpander.class);
+  }
+
+  @Test
+  void expanderInstances_shouldBeReused() {
+    /* this should register Strings with the SimpleExpander */
+    ExpressionExpander expander = expanderRegistry.getExpanderByType(String.class);
+
+    /* retrieve it again and it should be the same instance */
+    assertThat(expander).isEqualTo(expanderRegistry.getExpanderByType(String.class));
+  }
+
+  @Test
+  void customExpanderTypes_shouldBeInstantiated() {
+    ExpressionExpander expander = this.expanderRegistry.getExpander(CustomExpander.class);
+    assertThat(expander).isNotNull().isInstanceOf(CustomExpander.class);
+  }
+
+  @Test
+  void customExpanderTypes_shouldBeReused() {
+    ExpressionExpander expander = this.expanderRegistry.getExpander(CustomExpander.class);
+    assertThat(expander).isEqualTo(this.expanderRegistry.getExpander(CustomExpander.class));
+  }
+
+  @Test
+  void customExpanderTypes_mustHaveDefaultConstructor() {
+    assertThrows(IllegalStateException.class,
+        () -> this.expanderRegistry.getExpander(InvalidExpander.class));
+  }
+
+  static class CustomExpander implements ExpressionExpander {
+
+    @Override
+    public String expand(ExpressionVariable variable, Object value) {
+      return null;
+    }
+  }
+
+  static class InvalidExpander implements ExpressionExpander {
+
+    public InvalidExpander(String name) {
+      super();
+      Assert.isNotEmpty(name, "can't be empty");
+    }
+
+    @Override
+    public String expand(ExpressionVariable variable, Object value) {
+      return null;
+    }
+  }
+}

--- a/core/src/test/java/feign/template/expander/DefaultExpanderTest.java
+++ b/core/src/test/java/feign/template/expander/DefaultExpanderTest.java
@@ -14,22 +14,17 @@
  * limitations under the License.
  */
 
-package feign.template;
+package feign.template.expander;
 
-/**
- * Manages the expansion of a given Expression.  Implementations are expected to provide a
- * default, no-argument constructor and be thread-safe, to encourage lazy initialization and reuse
- * between {@link feign.Target}s.
- */
-public interface ExpressionExpander {
+import static org.junit.jupiter.api.Assertions.*;
 
-  /**
-   * Expand the given expression, using the value provided.
-   *
-   * @param variable to expand.
-   * @param value containing the variable values.
-   * @return the expanded result, an empty string, or {@literal null}.
-   */
-  String expand(ExpressionVariable variable, Object value);
+import org.junit.jupiter.api.Test;
 
+class DefaultExpanderTest {
+
+  @Test
+  void cannotBeUsed() {
+    DefaultExpander expander = new DefaultExpander();
+    assertThrows(UnsupportedOperationException.class, () -> expander.expand(null, null));
+  }
 }


### PR DESCRIPTION
Fixes #48

Created an ExpanderRegistry type that manages ExpressionExpander
instances for use within a given Feign Target.  This implementation
creates a single registry for a Contract instance.  This allows
the registry to be shared between Feign target instances, so long as
the Contract instance is shared.

An initial registry implementation, CachingExpanderRegistry, is provided
in this change.  This registry uses a ConcurrentHashMap to cache
Expander instances with their corresponding Java Types.  Custom Expanders
are also cached by their type name respectively and not the Java Types.
This is because we cannot know if a custom expander is meant for a single
type or many different ones, so to be safe, we just cache the instance.

Using the CachedExpanderRegistry, requires that all ExpressionExpanders
now be Thread Safe.  This should be OK considering the simple stateless
nature of expression expansion, but we must make sure that it is clear
to users.

Additional Changes:

* Adding Test Cases for CachingExpanderRegistry and Default Expander.
* Updated documentation on ExpressionExpander to inform implementations
that they must provide a default, no-argument constructor and be
thread safe.
* Adding Functional Tests for Custom Expander.
