### PR TITLE
Gh 47 object expansion

### DIFF
--- a/core/src/main/java/feign/template/ExpressionVariable.java
+++ b/core/src/main/java/feign/template/ExpressionVariable.java
@@ -87,6 +87,21 @@ public class ExpressionVariable {
   }
 
   /**
+   * Creates a new Expression Variable.
+   *
+   * @param prefix of the variable.
+   * @param name of the variable.
+   * @param exploded flag if this variable should be expanded into it's exploded form.
+   * @param expression this variable is part of.
+   */
+  public ExpressionVariable(int prefix, String name, boolean exploded, Expression expression) {
+    this.prefix = prefix;
+    this.name = name;
+    this.exploded = exploded;
+    this.expression = expression;
+  }
+
+  /**
    * Name of the variable.
    *
    * @return variable name.

--- a/core/src/main/java/feign/template/expander/BeanExpander.java
+++ b/core/src/main/java/feign/template/expander/BeanExpander.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2019 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.template.expander;
+
+import feign.support.StringUtils;
+import feign.template.ExpanderRegistry;
+import feign.template.ExpressionExpander;
+import feign.template.ExpressionVariable;
+import feign.template.Expressions;
+import java.beans.BeanInfo;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Expression Expander that is responsible for handling complex objects that adhere
+ * to the <a href="https://www.oracle.com/technetwork/articles/javaee/spec-136004.html">Java Bean Specification</a>.
+ * <p>
+ *   This expander will use the Introspector to identify any accessor methods on the the value
+ *   being expanded.  The result of the expansion will be the same as an associative array
+ *   per RFC 6570, honoring all explode, delimiter, and prefix modifiers.
+ * </p>
+ * <p>
+ *   Beans that contains Lists, Maps and other nested object will be expanded using the appropriate
+ *   {@link ExpressionExpander}, with the following limitations:
+ * </p>
+ * <ul>
+ *   <li>
+ *     Lists and Maps will be expanded in their non-exploded forms.
+ *   </li>
+ *   <li>
+ *     Lists and Maps that contain nested object will be exploded using the rules defined
+ *     by the {@link ListExpander} and {@link MapExpander} respectively, and not this expander.
+ *   </li>
+ *   <li>
+ *     Nested objects will be expanded prefixing their property names with the contained
+ *     property name.  ex: parent.nested = value.
+ *   </li>
+ * </ul>
+ */
+public class BeanExpander extends MapExpander {
+
+  private static BeanExpander instance;
+  private ExpanderRegistry expanderRegistry;
+
+  /**
+   * Returns a Singleton BeanExpander instance.
+   *
+   * @param expanderRegistry to use.
+   * @return a BeanExpander instance.
+   */
+  static BeanExpander getInstance(ExpanderRegistry expanderRegistry) {
+    if (instance == null) {
+      instance = new BeanExpander(expanderRegistry);
+    }
+    return instance;
+  }
+
+  /**
+   * Creates a new BeanExpander.
+   *
+   * @param expanderRegistry to use when expanding simple object properties.
+   */
+  BeanExpander(ExpanderRegistry expanderRegistry) {
+    this.expanderRegistry = expanderRegistry;
+  }
+
+  /**
+   * Expands the given value, which must be a simple Java Bean, by creating a Map of the
+   * accessible properties and delegating to the {@link MapExpander}.
+   *
+   * @param variable to expand.
+   * @param value containing the variable values.
+   * @return the expanded bean.
+   */
+  @Override
+  public String expand(ExpressionVariable variable, Object value) {
+    Map<String, Object> beanValueMap;
+    try {
+      beanValueMap = new LinkedHashMap<>(this.expandBean(variable, null, value));
+    } catch (Exception ex) {
+      throw new IllegalStateException("Error occurred expanding Bean "
+          + value.getClass().getSimpleName() + ".  " + ex.getMessage(), ex);
+    }
+    return super.expand(variable, beanValueMap);
+  }
+
+  /**
+   * Expand the provided Bean using an {@link Introspector} from the Java Beans API.  Each
+   * property with a valid read method will be read and added to a map, keyed by the property name.
+   * If the bean contains nested properties, the nested object will be expanded using the
+   * contained objects name as the property key prefix.
+   * <p>
+   *   ex: parent.nested = value
+   * </p>
+   *
+   * @param variable being expanded.
+   * @param parent of the bean provided, can be {@literal null}
+   * @param bean containing the values for the variable.
+   * @return a Map containing the bean property names and values.
+   * @throws Exception if an error occurred during expansion.
+   */
+  private Map<String, Object> expandBean(
+      ExpressionVariable variable, String parent, Object bean) throws Exception {
+    Map<String, Object> beanPropertyMap = new TreeMap<>();
+    BeanInfo info = Introspector.getBeanInfo(bean.getClass());
+    PropertyDescriptor[] descriptors = info.getPropertyDescriptors();
+    for (PropertyDescriptor propertyDescriptor : descriptors) {
+      String name = propertyDescriptor.getName();
+
+      /* class is a special property, we must ignore it or we end up with some very strange
+       * output.
+       */
+      if (!"class".equalsIgnoreCase(name)) {
+        if (StringUtils.isNotEmpty(parent)) {
+          /* nested objects use dot notation to indicate hierarchy */
+          name = parent + "." + name;
+        }
+
+        /* only properties with read methods are evaluated.  this allows users to manage property
+         * accessibility through methods instead of direct field access.  while direct field access
+         * is faster, this method provides the most flexibility and allows for logic on the
+         * bean side to be run before expansion.
+         */
+        Method readMethod = propertyDescriptor.getReadMethod();
+        if (readMethod != null) {
+          /* obtain the value */
+          Object result = readMethod.invoke(bean);
+          if (result != null) {
+            if (ExpanderUtils.isSimpleType(result.getClass())) {
+              /* use the expander registry to obtain an instance of the appropriate expander
+               * and delegate
+               */
+              ExpressionExpander expander =
+                  this.expanderRegistry.getExpanderByType(result.getClass());
+
+              /* we need to create a new variable so the expander can process the result
+               * in the correct context.
+               */
+              ExpressionVariable propertyVariable =
+                  new ExpressionVariable(variable.getPrefix(), name, variable.isExploded(),
+                      Expressions.create("{" + name + "}"));
+              String expanded = expander.expand(propertyVariable, result);
+              beanPropertyMap.put(name, expanded);
+            } else {
+              /* we have a nested object, expand it */
+              beanPropertyMap.putAll(this.expandBean(variable, name, result));
+            }
+          }
+        }
+      }
+    }
+    return beanPropertyMap;
+  }
+}

--- a/core/src/main/java/feign/template/expander/CachingExpanderRegistry.java
+++ b/core/src/main/java/feign/template/expander/CachingExpanderRegistry.java
@@ -40,12 +40,14 @@ public class CachingExpanderRegistry implements ExpanderRegistry {
     /* uses singleton instances for our internal expander instances */
     return this.expanderMapCache.computeIfAbsent(parameterType,
         type -> {
-          if (Iterable.class.isAssignableFrom(parameterType)) {
+          if (Iterable.class.isAssignableFrom(type)) {
             return ListExpander.getInstance();
-          } else if (Map.class.isAssignableFrom(parameterType)) {
+          } else if (Map.class.isAssignableFrom(type)) {
             return MapExpander.getInstance();
-          } else {
+          } else if (ExpanderUtils.isSimpleType(type)) {
             return SimpleExpander.getInstance();
+          } else {
+            return BeanExpander.getInstance(this);
           }
         });
   }
@@ -71,4 +73,6 @@ public class CachingExpanderRegistry implements ExpanderRegistry {
           }
         });
   }
+
+
 }

--- a/core/src/main/java/feign/template/expander/ExpanderUtils.java
+++ b/core/src/main/java/feign/template/expander/ExpanderUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.template.expander;
+
+import java.util.Map;
+
+/**
+ * Utilities related to variable expansion.
+ */
+class ExpanderUtils {
+
+  /**
+   * Determines if the provided Class is <em>simple</em>.  That is, something that is
+   * not a core primitive, enum, annotation, array, String, Iterable, or Map.
+   *
+   * @param type to be evaluated.
+   * @return {@literal true} if the type is considered <em>simple</em>, {@literal false} otherwise.
+   */
+  static boolean isSimpleType(Class<?> type) {
+    return type.isAnnotation() || type.isArray() || type.isEnum() || type.isPrimitive()
+        || String.class == type || Iterable.class.isAssignableFrom(type)
+        || Map.class.isAssignableFrom(type);
+  }
+
+}

--- a/core/src/test/java/feign/template/expander/BeanExpanderTest.java
+++ b/core/src/test/java/feign/template/expander/BeanExpanderTest.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright 2019 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.template.expander;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import feign.template.ExpanderRegistry;
+import feign.template.Expression;
+import feign.template.ExpressionVariable;
+import feign.template.Expressions;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class BeanExpanderTest {
+
+  @Test
+  void simpleObject_expandLikeMap_withUndefinedValue_Missing() {
+    Address address = new Address();
+    address.setStreetNumber("121B");
+    address.setStreetName("Baker St.");
+    address.setTown("London");
+    address.setCountry("England");
+    address.setGivenName("Sherlock");
+    address.setSurname("Holmes");
+
+    ExpressionVariable expressionVariable = mock(ExpressionVariable.class);
+    Expression expression = Expressions.create("{?address*}");
+
+    when(expressionVariable.getName()).thenReturn("address");
+    when(expressionVariable.getPrefix()).thenReturn(0);
+    when(expressionVariable.getExpression()).thenReturn(expression);
+    when(expressionVariable.isExploded()).thenReturn(true);
+
+    BeanExpander expander = new BeanExpander(new CachingExpanderRegistry());
+    String expanded = expander.expand(expressionVariable, address);
+    assertThat(expanded).isEqualToIgnoringCase("country=England&givenName=Sherlock&"
+        + "streetName=Baker%20St.&streetNumber=121B&surname=Holmes"
+        + "&town=London");
+  }
+
+  @Test
+  void nestedObjects_expandWith_dotNotation() {
+    Post post = new Post("Title", "Summary");
+    post.setCategory("sports");
+    post.addTag("hockey");
+    post.addTag("ice");
+    post.addTag("Canada");
+
+    BeanExpander expander = new BeanExpander(new CachingExpanderRegistry());
+    ExpressionVariable expressionVariable = mock(ExpressionVariable.class);
+    Expression expression = Expressions.create("{?post*}");
+
+    when(expressionVariable.getName()).thenReturn("post");
+    when(expressionVariable.getPrefix()).thenReturn(0);
+    when(expressionVariable.getExpression()).thenReturn(expression);
+    when(expressionVariable.isExploded()).thenReturn(true);
+
+    String expanded = expander.expand(expressionVariable, post);
+    assertThat(expanded).isEqualToIgnoringCase(
+        "category.label=sports&category.name=sports&summary=Summary&tags=hockey%2Cice%2CCanada&title=Title");
+  }
+
+  @Test
+  void property_withoutReadMethod_isSkipped() {
+    Post post = new Post("Title", "Summary");
+    post.setCategory("sports");
+    post.addTag("hockey");
+    post.addTag("ice");
+    post.addTag("Canada");
+    post.setPublished(LocalDateTime.now());
+
+    BeanExpander expander = new BeanExpander(new CachingExpanderRegistry());
+    ExpressionVariable expressionVariable = mock(ExpressionVariable.class);
+    Expression expression = Expressions.create("{?post*}");
+
+    when(expressionVariable.getName()).thenReturn("post");
+    when(expressionVariable.getPrefix()).thenReturn(0);
+    when(expressionVariable.getExpression()).thenReturn(expression);
+    when(expressionVariable.isExploded()).thenReturn(true);
+
+    String expanded = expander.expand(expressionVariable, post);
+    assertThat(expanded).isEqualToIgnoringCase(
+        "category.label=sports&category.name=sports&summary=Summary&tags=hockey%2Cice%2CCanada&title=Title");
+  }
+
+  @Test
+  void singletonCreation_shouldLazyLoad_andReuse() {
+    BeanExpander beanExpander = BeanExpander.getInstance(mock(ExpanderRegistry.class));
+    assertThat(beanExpander).isNotNull();
+
+    BeanExpander another = BeanExpander.getInstance(mock(ExpanderRegistry.class));
+    assertThat(another).isEqualTo(beanExpander);
+  }
+
+  public class Address {
+    private String givenName;
+    private String surname;
+    private String streetNumber;
+    private String streetName;
+    private String streetType;
+    private String floor;
+    private String town;
+    private String region;
+    private String postalCode;
+    private String country;
+
+    public Address() {
+      super();
+    }
+
+    public String getGivenName() {
+      return givenName;
+    }
+
+    public void setGivenName(String givenName) {
+      this.givenName = givenName;
+    }
+
+    public String getSurname() {
+      return surname;
+    }
+
+    public void setSurname(String surname) {
+      this.surname = surname;
+    }
+
+    public String getStreetNumber() {
+      return streetNumber;
+    }
+
+    public void setStreetNumber(String streetNumber) {
+      this.streetNumber = streetNumber;
+    }
+
+    public String getStreetName() {
+      return streetName;
+    }
+
+    public void setStreetName(String streetName) {
+      this.streetName = streetName;
+    }
+
+    public String getStreetType() {
+      return streetType;
+    }
+
+    public void setStreetType(String streetType) {
+      this.streetType = streetType;
+    }
+
+    public String getFloor() {
+      return floor;
+    }
+
+    public void setFloor(String floor) {
+      this.floor = floor;
+    }
+
+    public String getTown() {
+      return town;
+    }
+
+    public void setTown(String town) {
+      this.town = town;
+    }
+
+    public String getRegion() {
+      return region;
+    }
+
+    public void setRegion(String region) {
+      this.region = region;
+    }
+
+    public String getPostalCode() {
+      return postalCode;
+    }
+
+    public void setPostalCode(String postalCode) {
+      this.postalCode = postalCode;
+    }
+
+    public String getCountry() {
+      return country;
+    }
+
+    public void setCountry(String country) {
+      this.country = country;
+    }
+  }
+
+  public class Post {
+    private String title;
+    private String summary;
+    private Category category;
+    private List<Tag> tags = new ArrayList<>();
+    private LocalDateTime published;
+
+    public Post() {
+      super();
+    }
+
+    public Post(String title, String summary) {
+      this.title = title;
+      this.summary = summary;
+    }
+
+    public String getTitle() {
+      return title;
+    }
+
+    public String getSummary() {
+      return summary;
+    }
+
+    public void setCategory(String category) {
+      this.category = new Category(category);
+    }
+
+    public Category getCategory() {
+      return this.category;
+    }
+
+    public void addTag(String tag) {
+      this.tags.add(new Tag(tag));
+    }
+
+    public List<Tag> getTags() {
+      return this.tags;
+    }
+
+    public void setPublished(LocalDateTime published) {
+      this.published = published;
+    }
+  }
+
+  public class Tag {
+    private String name;
+
+    public Tag() {
+      super();
+    }
+
+    public Tag(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String toString() {
+      return this.getName();
+    }
+  }
+
+  public class Category {
+    private String scheme;
+    private String name;
+    private String label;
+
+    public Category() {
+      super();
+    }
+
+    public Category(String name) {
+      this.label = name;
+      this.name = name;
+    }
+
+    public String getScheme() {
+      return scheme;
+    }
+
+    public void setScheme(String scheme) {
+      this.scheme = scheme;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+
+    public void setLabel(String label) {
+      this.label = label;
+    }
+  }
+
+  public class BadBean {
+    private String name;
+    private List<BadProperty> props = new ArrayList<>();
+
+    public BadBean() {
+      super();
+      props.add(new BadProperty());
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public List<BadProperty> getProps() {
+      return props;
+    }
+
+    public void setProps(List<BadProperty> props) {
+      this.props = props;
+    }
+  }
+
+  public class BadProperty {
+    public BadProperty() {
+      super();
+    }
+
+    @Override
+    public String toString() {
+      throw new UnsupportedOperationException("bad property doesn't have a to string");
+    }
+
+  }
+}

--- a/core/src/test/java/feign/template/expander/CachingExpanderRegistryTest.java
+++ b/core/src/test/java/feign/template/expander/CachingExpanderRegistryTest.java
@@ -48,6 +48,12 @@ class CachingExpanderRegistryTest {
   }
 
   @Test
+  void complexType_shouldBeExpandedWith_BeanExpander() {
+    assertThat(this.expanderRegistry.getExpanderByType(SimpleExpander.class))
+        .isInstanceOf(BeanExpander.class);
+  }
+
+  @Test
   void expanderInstances_shouldBeReused() {
     /* this should register Strings with the SimpleExpander */
     ExpressionExpander expander = expanderRegistry.getExpanderByType(String.class);

--- a/core/src/test/java/feign/template/expander/ExpanderUtilsTest.java
+++ b/core/src/test/java/feign/template/expander/ExpanderUtilsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.template.expander;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import feign.contract.Param;
+import java.beans.Introspector;
+import org.junit.jupiter.api.Test;
+
+class ExpanderUtilsTest {
+
+  @Test
+  void enum_isSimple() {
+    Constants constants = Constants.ONE;
+    assertThat(ExpanderUtils.isSimpleType(constants.getClass())).isTrue();
+  }
+
+  @Test
+  void array_isSimple() {
+    int[] numbers = new int[10];
+    assertThat(ExpanderUtils.isSimpleType(numbers.getClass())).isTrue();
+  }
+
+  @Test
+  void annotation_isSimple() {
+    assertThat(ExpanderUtils.isSimpleType(Param.class)).isTrue();
+  }
+
+  @Test
+  void primitive_isSimple() {
+    assertThat(ExpanderUtils.isSimpleType(int.class)).isTrue();
+  }
+
+  @Test
+  void number_isNotSimple() {
+    assertThat(ExpanderUtils.isSimpleType(Integer.class)).isFalse();
+  }
+
+  @Test
+  void string_isSimple() {
+    assertThat(ExpanderUtils.isSimpleType(String.class)).isTrue();
+  }
+
+  @Test
+  void iterable_isSimple() {
+    assertThat(ExpanderUtils.isSimpleType(Iterable.class)).isTrue();
+  }
+
+  @Test
+  void map_isSimple() {
+    assertThat(ExpanderUtils.isSimpleType(Iterable.class)).isTrue();
+  }
+
+  @Test
+  void pojo_isNotSimple() {
+    assertThat(ExpanderUtils.isSimpleType(SimpleObject.class)).isFalse();
+
+  }
+
+  enum Constants {
+    ONE
+  }
+
+  private class SimpleObject {
+
+  }
+}

--- a/core/src/test/java/feign/template/expander/ExpanderUtilsTest.java
+++ b/core/src/test/java/feign/template/expander/ExpanderUtilsTest.java
@@ -17,10 +17,8 @@
 package feign.template.expander;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import feign.contract.Param;
-import java.beans.Introspector;
 import org.junit.jupiter.api.Test;
 
 class ExpanderUtilsTest {

--- a/core/src/test/java/feign/template/expander/ExpanderUtilsTest.java
+++ b/core/src/test/java/feign/template/expander/ExpanderUtilsTest.java
@@ -19,6 +19,7 @@ package feign.template.expander;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import feign.contract.Param;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class ExpanderUtilsTest {
@@ -62,7 +63,7 @@ class ExpanderUtilsTest {
 
   @Test
   void map_isSimple() {
-    assertThat(ExpanderUtils.isSimpleType(Iterable.class)).isTrue();
+    assertThat(ExpanderUtils.isSimpleType(Map.class)).isTrue();
   }
 
   @Test


### PR DESCRIPTION
Fixes #47

Adds support for expanding simple objects as part of a Uri Template.
This feature uses the Java Beans api to inspect the object, relying
on the read methods for the bean's properties to determine what
information should be included in the expansion.

Nested object are also expanded, their names will be prefixed
with a dot ".".  Example "person.address".

Nested Lists and Maps are delegated to their respective expanders.
All other values are expanded using the `SimpleExpander`.

This implementation will fit for the most common simple use cases.
Complex use cases such as generic variables, interfaces, and
inheritance have not been tested and considered unsupported at
this time.

Lastly, Dates are expanded using their `toString` representation.
We may want to consider a date formatting option in the future.