### PR TITLE
Baseline on JDK 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,8 +119,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.0</version>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <release>11</release>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Set the maven compiler to use JDK 11 for all builds going forward.