### PR TITLE
Introduce TargetMethodMetadata.builder for thread-safe construction

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2019 OpenFeign Contributors
+    Copyright 2019-2020 OpenFeign Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -40,7 +40,14 @@
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
-      <scope>provided</scope>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>net.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+      <scope>compile</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>

--- a/core/src/main/java/feign/Client.java
+++ b/core/src/main/java/feign/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/ExceptionHandler.java
+++ b/core/src/main/java/feign/ExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/FeignConfiguration.java
+++ b/core/src/main/java/feign/FeignConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/FeignConfigurationBuilder.java
+++ b/core/src/main/java/feign/FeignConfigurationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/Header.java
+++ b/core/src/main/java/feign/Header.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/Logger.java
+++ b/core/src/main/java/feign/Logger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/Request.java
+++ b/core/src/main/java/feign/Request.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/RequestEncoder.java
+++ b/core/src/main/java/feign/RequestEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/RequestInterceptor.java
+++ b/core/src/main/java/feign/RequestInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/RequestOptions.java
+++ b/core/src/main/java/feign/RequestOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/ResponseDecoder.java
+++ b/core/src/main/java/feign/ResponseDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/Retry.java
+++ b/core/src/main/java/feign/Retry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/Target.java
+++ b/core/src/main/java/feign/Target.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/TargetMethodHandler.java
+++ b/core/src/main/java/feign/TargetMethodHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/TargetMethodHandlerFactory.java
+++ b/core/src/main/java/feign/TargetMethodHandlerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/contract/Body.java
+++ b/core/src/main/java/feign/contract/Body.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/contract/FeignContract.java
+++ b/core/src/main/java/feign/contract/FeignContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import java.util.List;
  */
 public class FeignContract extends AbstractAnnotationDrivenContract {
 
-  private ExpanderRegistry expanderRegistry = new CachingExpanderRegistry();
+  private final ExpanderRegistry expanderRegistry = new CachingExpanderRegistry();
 
   /**
    * Creates a new Feign Contract.
@@ -55,7 +55,7 @@ public class FeignContract extends AbstractAnnotationDrivenContract {
    */
   @Override
   protected void processAnnotationsOnType(Class<?> targetType,
-      TargetMethodDefinition targetMethodDefinition) {
+      TargetMethodDefinition.Builder targetMethodDefinition) {
     if (targetType.isAnnotationPresent(Request.class)) {
       this.processRequest(targetType.getAnnotation(Request.class), targetMethodDefinition);
     }
@@ -73,7 +73,7 @@ public class FeignContract extends AbstractAnnotationDrivenContract {
    */
   @Override
   protected void processAnnotationsOnMethod(Class<?> targetType, Method method,
-      TargetMethodDefinition targetMethodDefinition) {
+      TargetMethodDefinition.Builder targetMethodDefinition) {
     if (method.isAnnotationPresent(Request.class)) {
       targetMethodDefinition
           .name(method.getName())
@@ -95,7 +95,7 @@ public class FeignContract extends AbstractAnnotationDrivenContract {
    */
   @Override
   protected void processAnnotationsOnParameter(Parameter parameter, Integer parameterIndex,
-      TargetMethodDefinition targetMethodDefinition) {
+      TargetMethodDefinition.Builder targetMethodDefinition) {
     if (parameter.isAnnotationPresent(Param.class)) {
       this.processParameter(
           parameter.getAnnotation(Param.class),
@@ -114,7 +114,8 @@ public class FeignContract extends AbstractAnnotationDrivenContract {
    * @param request annotation to process.
    * @param targetMethodDefinition for the request.
    */
-  private void processRequest(Request request, TargetMethodDefinition targetMethodDefinition) {
+  private void processRequest(Request request,
+      TargetMethodDefinition.Builder targetMethodDefinition) {
     String uri = (StringUtils.isNotEmpty(request.uri())) ? request.uri() : request.value();
     HttpMethod httpMethod = request.method();
     boolean followRedirects = request.followRedirects();
@@ -132,7 +133,8 @@ public class FeignContract extends AbstractAnnotationDrivenContract {
    * @param headers annotation to process.
    * @param targetMethodDefinition for the request.
    */
-  private void processHeaders(Headers headers, TargetMethodDefinition targetMethodDefinition) {
+  private void processHeaders(Headers headers,
+      TargetMethodDefinition.Builder targetMethodDefinition) {
     if (headers.value().length != 0) {
       Header[] header = headers.value();
       for (Header value : header) {
@@ -147,7 +149,7 @@ public class FeignContract extends AbstractAnnotationDrivenContract {
    * @param header annotation to process.
    * @param targetMethodDefinition for the header.
    */
-  private void processHeader(Header header, TargetMethodDefinition targetMethodDefinition) {
+  private void processHeader(Header header, TargetMethodDefinition.Builder targetMethodDefinition) {
     HttpHeader httpHeader = new HttpHeader(header.name());
     httpHeader.value(header.value());
     targetMethodDefinition.header(httpHeader);
@@ -162,7 +164,7 @@ public class FeignContract extends AbstractAnnotationDrivenContract {
    * @param targetMethodDefinition for the parameter.
    */
   private void processParameter(Param parameter, Integer index, Class<?> type,
-      TargetMethodDefinition targetMethodDefinition) {
+      TargetMethodDefinition.Builder targetMethodDefinition) {
     String name = parameter.value();
     Class<? extends ExpressionExpander> expanderClass = parameter.expander();
 
@@ -181,7 +183,7 @@ public class FeignContract extends AbstractAnnotationDrivenContract {
   }
 
   /**
-   * Constructs a name for a Method that is formatted as a {@link com.sun.javadoc.SeeTag}.
+   * Constructs a name for a Method that is formatted as a javadoc reference.
    *
    * @param targetType containing the method.
    * @param method to inspect.

--- a/core/src/main/java/feign/contract/Header.java
+++ b/core/src/main/java/feign/contract/Header.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/contract/Headers.java
+++ b/core/src/main/java/feign/contract/Headers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/contract/Param.java
+++ b/core/src/main/java/feign/contract/Param.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/contract/Request.java
+++ b/core/src/main/java/feign/contract/Request.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/decoder/AbstractResponseDecoder.java
+++ b/core/src/main/java/feign/decoder/AbstractResponseDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/decoder/StringDecoder.java
+++ b/core/src/main/java/feign/decoder/StringDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/encoder/StringEncoder.java
+++ b/core/src/main/java/feign/encoder/StringEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/exception/FeignException.java
+++ b/core/src/main/java/feign/exception/FeignException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/http/HttpException.java
+++ b/core/src/main/java/feign/http/HttpException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/http/HttpHeader.java
+++ b/core/src/main/java/feign/http/HttpHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ public class HttpHeader implements Header {
           "Vary");
   private final String name;
   private final Set<String> values = new LinkedHashSet<>();
-  private boolean multipleValuesAllowed;
+  private final boolean multipleValuesAllowed;
 
   /**
    * Creates a new HttpHeader.

--- a/core/src/main/java/feign/http/HttpMethod.java
+++ b/core/src/main/java/feign/http/HttpMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/http/HttpRequest.java
+++ b/core/src/main/java/feign/http/HttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/http/HttpResponse.java
+++ b/core/src/main/java/feign/http/HttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/http/RequestSpecification.java
+++ b/core/src/main/java/feign/http/RequestSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/http/client/UrlConnectionClient.java
+++ b/core/src/main/java/feign/http/client/UrlConnectionClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/impl/AbstractFeignConfigurationBuilder.java
+++ b/core/src/main/java/feign/impl/AbstractFeignConfigurationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/impl/AbstractTarget.java
+++ b/core/src/main/java/feign/impl/AbstractTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/impl/AbstractTargetMethodHandler.java
+++ b/core/src/main/java/feign/impl/AbstractTargetMethodHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/impl/AsyncTargetMethodHandler.java
+++ b/core/src/main/java/feign/impl/AsyncTargetMethodHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/impl/BaseFeignConfiguration.java
+++ b/core/src/main/java/feign/impl/BaseFeignConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/impl/BlockingTargetMethodHandler.java
+++ b/core/src/main/java/feign/impl/BlockingTargetMethodHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/impl/TypeDrivenMethodHandlerFactory.java
+++ b/core/src/main/java/feign/impl/TypeDrivenMethodHandlerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/impl/UriTarget.java
+++ b/core/src/main/java/feign/impl/UriTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/impl/type/AbstractTypeDefinition.java
+++ b/core/src/main/java/feign/impl/type/AbstractTypeDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/impl/type/ClassTypeDefinition.java
+++ b/core/src/main/java/feign/impl/type/ClassTypeDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/impl/type/GenericArrayTypeDefinition.java
+++ b/core/src/main/java/feign/impl/type/GenericArrayTypeDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/impl/type/ParameterizedTypeDefinition.java
+++ b/core/src/main/java/feign/impl/type/ParameterizedTypeDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/impl/type/TypeDefinition.java
+++ b/core/src/main/java/feign/impl/type/TypeDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/impl/type/TypeDefinitionFactory.java
+++ b/core/src/main/java/feign/impl/type/TypeDefinitionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/impl/type/WildCardTypeDefinition.java
+++ b/core/src/main/java/feign/impl/type/WildCardTypeDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/logging/AbstractLogger.java
+++ b/core/src/main/java/feign/logging/AbstractLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/logging/SimpleLogger.java
+++ b/core/src/main/java/feign/logging/SimpleLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/proxy/GuardMethodHandler.java
+++ b/core/src/main/java/feign/proxy/GuardMethodHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/proxy/ProxyFeign.java
+++ b/core/src/main/java/feign/proxy/ProxyFeign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/proxy/ProxyTarget.java
+++ b/core/src/main/java/feign/proxy/ProxyTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/retry/BackoffRetryInterval.java
+++ b/core/src/main/java/feign/retry/BackoffRetryInterval.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/retry/ConditionalRetry.java
+++ b/core/src/main/java/feign/retry/ConditionalRetry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/retry/ConditionalRetryBuilder.java
+++ b/core/src/main/java/feign/retry/ConditionalRetryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/retry/ExceptionCondition.java
+++ b/core/src/main/java/feign/retry/ExceptionCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/retry/NoRetry.java
+++ b/core/src/main/java/feign/retry/NoRetry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/retry/RetryAfterHeaderInterval.java
+++ b/core/src/main/java/feign/retry/RetryAfterHeaderInterval.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/retry/RetryCondition.java
+++ b/core/src/main/java/feign/retry/RetryCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/retry/RetryContext.java
+++ b/core/src/main/java/feign/retry/RetryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/retry/RetryInterval.java
+++ b/core/src/main/java/feign/retry/RetryInterval.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/retry/StatusCodeCondition.java
+++ b/core/src/main/java/feign/retry/StatusCodeCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/support/Assert.java
+++ b/core/src/main/java/feign/support/Assert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/support/StringUtils.java
+++ b/core/src/main/java/feign/support/StringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/Chunk.java
+++ b/core/src/main/java/feign/template/Chunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/DotExpansionPolicy.java
+++ b/core/src/main/java/feign/template/DotExpansionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/ExpanderRegistry.java
+++ b/core/src/main/java/feign/template/ExpanderRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/ExpansionPolicy.java
+++ b/core/src/main/java/feign/template/ExpansionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/Expression.java
+++ b/core/src/main/java/feign/template/Expression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/ExpressionExpander.java
+++ b/core/src/main/java/feign/template/ExpressionExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/ExpressionVariable.java
+++ b/core/src/main/java/feign/template/ExpressionVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/Expressions.java
+++ b/core/src/main/java/feign/template/Expressions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/FormContinuationStyleExpansionPolicy.java
+++ b/core/src/main/java/feign/template/FormContinuationStyleExpansionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/FormStyleExpansionPolicy.java
+++ b/core/src/main/java/feign/template/FormStyleExpansionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/FragmentExpansionPolicy.java
+++ b/core/src/main/java/feign/template/FragmentExpansionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/Literal.java
+++ b/core/src/main/java/feign/template/Literal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/PathSegmentExpansionPolicy.java
+++ b/core/src/main/java/feign/template/PathSegmentExpansionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/PathStyleExpansionPolicy.java
+++ b/core/src/main/java/feign/template/PathStyleExpansionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/ReservedExpansionPolicy.java
+++ b/core/src/main/java/feign/template/ReservedExpansionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/SimpleExpansionPolicy.java
+++ b/core/src/main/java/feign/template/SimpleExpansionPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/SimpleTemplateParameter.java
+++ b/core/src/main/java/feign/template/SimpleTemplateParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/TemplateParameter.java
+++ b/core/src/main/java/feign/template/TemplateParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/UriTemplate.java
+++ b/core/src/main/java/feign/template/UriTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/UriUtils.java
+++ b/core/src/main/java/feign/template/UriUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/expander/BeanExpander.java
+++ b/core/src/main/java/feign/template/expander/BeanExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/expander/CachingExpanderRegistry.java
+++ b/core/src/main/java/feign/template/expander/CachingExpanderRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/expander/DefaultExpander.java
+++ b/core/src/main/java/feign/template/expander/DefaultExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/expander/ExpanderUtils.java
+++ b/core/src/main/java/feign/template/expander/ExpanderUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/expander/ListExpander.java
+++ b/core/src/main/java/feign/template/expander/ListExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/expander/MapExpander.java
+++ b/core/src/main/java/feign/template/expander/MapExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/expander/MultiValueExpander.java
+++ b/core/src/main/java/feign/template/expander/MultiValueExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/feign/template/expander/SimpleExpander.java
+++ b/core/src/main/java/feign/template/expander/SimpleExpander.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/FeignTests.java
+++ b/core/src/test/java/feign/FeignTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/RequestOptionsTest.java
+++ b/core/src/test/java/feign/RequestOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/TargetMethodDefinitionTest.java
+++ b/core/src/test/java/feign/TargetMethodDefinitionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,45 +25,60 @@ class TargetMethodDefinitionTest {
 
   @Test
   void getUri_alwaysReturnsAValue() {
-    TargetMethodDefinition targetMethodDefinition = new TargetMethodDefinition(mock(Target.class));
+    TargetMethodDefinition targetMethodDefinition =
+        TargetMethodDefinition.builder(mock(Target.class))
+            .build();
     assertThat(targetMethodDefinition.getUri()).isNotNull();
   }
 
   @Test
   void equals_name_caseSensitive() {
-    TargetMethodDefinition targetMethodDefinition = new TargetMethodDefinition(mock(Target.class));
-    targetMethodDefinition.name("name");
+    TargetMethodDefinition targetMethodDefinition =
+        TargetMethodDefinition.builder(mock(Target.class))
+            .name("name")
+            .build();
 
-    TargetMethodDefinition anotherDefinition = new TargetMethodDefinition(mock(Target.class));
-    anotherDefinition.name("name");
+    TargetMethodDefinition anotherDefinition =
+        TargetMethodDefinition.builder(mock(Target.class))
+            .name("name")
+            .build();
     assertThat(targetMethodDefinition).isEqualTo(anotherDefinition);
   }
 
   @Test
   void equals_itself() {
-    TargetMethodDefinition targetMethodDefinition = new TargetMethodDefinition(mock(Target.class));
+    TargetMethodDefinition targetMethodDefinition =
+        TargetMethodDefinition.builder(mock(Target.class))
+            .build();
     assertThat(targetMethodDefinition).isEqualTo(targetMethodDefinition);
   }
 
   @Test
   void notEqual_toOtherTypes() {
-    TargetMethodDefinition targetMethodDefinition = new TargetMethodDefinition(mock(Target.class));
+    TargetMethodDefinition targetMethodDefinition =
+        TargetMethodDefinition.builder(mock(Target.class))
+            .build();
     assertThat(targetMethodDefinition).isNotEqualTo("A String");
   }
 
   @Test
   void notEqual_name_caseSensitive() {
-    TargetMethodDefinition targetMethodDefinition = new TargetMethodDefinition(mock(Target.class));
-    targetMethodDefinition.name("Name");
+    TargetMethodDefinition targetMethodDefinition =
+        TargetMethodDefinition.builder(mock(Target.class))
+            .name("name")
+            .build();
 
-    TargetMethodDefinition anotherDefinition = new TargetMethodDefinition(mock(Target.class));
-    anotherDefinition.name("name");
+    TargetMethodDefinition anotherDefinition =
+        TargetMethodDefinition.builder(mock(Target.class))
+            .name("Name")
+            .build();
     assertThat(targetMethodDefinition).isNotEqualTo(anotherDefinition);
   }
 
   @Test
   void toString_isNotEmpty() {
-    TargetMethodDefinition targetMethodDefinition = new TargetMethodDefinition(mock(Target.class));
+    TargetMethodDefinition targetMethodDefinition =
+        TargetMethodDefinition.builder(mock(Target.class)).build();
     assertThat(targetMethodDefinition.toString()).isNotEmpty();
   }
 }

--- a/core/src/test/java/feign/assertions/AbstractHttpHeaderAssert.java
+++ b/core/src/test/java/feign/assertions/AbstractHttpHeaderAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/assertions/AbstractHttpRequestAssert.java
+++ b/core/src/test/java/feign/assertions/AbstractHttpRequestAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/assertions/AbstractHttpResponseAssert.java
+++ b/core/src/test/java/feign/assertions/AbstractHttpResponseAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/assertions/Assertions.java
+++ b/core/src/test/java/feign/assertions/Assertions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/assertions/HttpHeaderAssert.java
+++ b/core/src/test/java/feign/assertions/HttpHeaderAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/assertions/HttpRequestAssert.java
+++ b/core/src/test/java/feign/assertions/HttpRequestAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/assertions/HttpResponseAssert.java
+++ b/core/src/test/java/feign/assertions/HttpResponseAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/contract/FeignContractTest.java
+++ b/core/src/test/java/feign/contract/FeignContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/decoder/AbstractResponseDecoderTest.java
+++ b/core/src/test/java/feign/decoder/AbstractResponseDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/decoder/StringDecoderTest.java
+++ b/core/src/test/java/feign/decoder/StringDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/encoder/StringEncoderTest.java
+++ b/core/src/test/java/feign/encoder/StringEncoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/exception/FeignExceptionTest.java
+++ b/core/src/test/java/feign/exception/FeignExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/exception/RethrowExceptionHandlerTest.java
+++ b/core/src/test/java/feign/exception/RethrowExceptionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/http/HttpExceptionTest.java
+++ b/core/src/test/java/feign/http/HttpExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/http/HttpHeaderTest.java
+++ b/core/src/test/java/feign/http/HttpHeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/http/HttpRequestTest.java
+++ b/core/src/test/java/feign/http/HttpRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/http/HttpResponseTest.java
+++ b/core/src/test/java/feign/http/HttpResponseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/http/RequestSpecificationTest.java
+++ b/core/src/test/java/feign/http/RequestSpecificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/http/client/UrlConnectionClientIntegrationTest.java
+++ b/core/src/test/java/feign/http/client/UrlConnectionClientIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/impl/AbstractTargetMethodHandlerTest.java
+++ b/core/src/test/java/feign/impl/AbstractTargetMethodHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import feign.Client;
+import feign.ExceptionHandler;
 import feign.ExceptionHandler.RethrowExceptionHandler;
 import feign.Logger;
 import feign.Request;
@@ -39,7 +40,6 @@ import feign.ResponseDecoder;
 import feign.Retry;
 import feign.TargetMethodDefinition;
 import feign.TargetMethodHandler;
-import feign.ExceptionHandler;
 import feign.http.HttpMethod;
 import feign.http.RequestSpecification;
 import feign.retry.NoRetry;
@@ -60,7 +60,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class AbstractTargetMethodHandlerTest {
 
-  private TargetMethodDefinition targetMethodDefinition;
+  private TargetMethodDefinition.Builder targetMethodDefinition;
 
   @Mock
   private RequestEncoder encoder;
@@ -89,7 +89,7 @@ class AbstractTargetMethodHandlerTest {
 
   @BeforeEach
   void setUp() {
-    this.targetMethodDefinition = new TargetMethodDefinition(
+    this.targetMethodDefinition = TargetMethodDefinition.builder(
         new UriTarget<>(TestInterface.class, "https://www.example.com"));
 
   }
@@ -103,9 +103,9 @@ class AbstractTargetMethodHandlerTest {
         .method(HttpMethod.GET)
         .templateParameter(0, new SimpleTemplateParameter("name"))
         .body(1);
-
+    TargetMethodDefinition methodDefinition = this.targetMethodDefinition.build();
     TargetMethodHandler targetMethodHandler = new BlockingTargetMethodHandler(
-        this.targetMethodDefinition,
+        methodDefinition,
         this.encoder,
         Collections.singletonList(this.interceptor),
         this.client,
@@ -133,8 +133,9 @@ class AbstractTargetMethodHandlerTest {
         .templateParameter(0, new SimpleTemplateParameter("name"))
         .body(1);
 
+    TargetMethodDefinition methodDefinition = this.targetMethodDefinition.build();
     TargetMethodHandler targetMethodHandler = new BlockingTargetMethodHandler(
-        this.targetMethodDefinition,
+        methodDefinition,
         this.encoder,
         null,
         this.client,
@@ -160,8 +161,9 @@ class AbstractTargetMethodHandlerTest {
             .method(HttpMethod.GET)
             .templateParameter(0, new SimpleTemplateParameter("name"));
 
+    TargetMethodDefinition methodDefinition = this.targetMethodDefinition.build();
     TargetMethodHandler targetMethodHandler = new BlockingTargetMethodHandler(
-        this.targetMethodDefinition,
+        methodDefinition,
         this.encoder,
         Collections.singletonList(this.interceptor),
         this.client,
@@ -187,8 +189,9 @@ class AbstractTargetMethodHandlerTest {
         .method(HttpMethod.GET)
         .templateParameter(0, new SimpleTemplateParameter("name"));
 
+    TargetMethodDefinition methodDefinition = this.targetMethodDefinition.build();
     TargetMethodHandler targetMethodHandler = new BlockingTargetMethodHandler(
-        this.targetMethodDefinition,
+        methodDefinition,
         this.encoder,
         Collections.singletonList(this.interceptor),
         this.client,
@@ -212,8 +215,9 @@ class AbstractTargetMethodHandlerTest {
         .method(HttpMethod.GET)
         .templateParameter(0, new SimpleTemplateParameter("name"));
 
+    TargetMethodDefinition methodDefinition = this.targetMethodDefinition.build();
     TargetMethodHandler targetMethodHandler = new BlockingTargetMethodHandler(
-        this.targetMethodDefinition,
+        methodDefinition,
         this.encoder,
         Collections.singletonList(this.interceptor),
         this.client,
@@ -238,8 +242,9 @@ class AbstractTargetMethodHandlerTest {
         .method(HttpMethod.GET)
         .templateParameter(0, new SimpleTemplateParameter("name"));
 
+    TargetMethodDefinition methodDefinition = this.targetMethodDefinition.build();
     TargetMethodHandler targetMethodHandler = new BlockingTargetMethodHandler(
-        this.targetMethodDefinition,
+        methodDefinition,
         this.encoder,
         Collections.singletonList(this.interceptor),
         this.client,
@@ -264,8 +269,9 @@ class AbstractTargetMethodHandlerTest {
         .method(HttpMethod.GET)
         .templateParameter(0, new SimpleTemplateParameter("name"));
 
+    TargetMethodDefinition methodDefinition = this.targetMethodDefinition.build();
     TargetMethodHandler targetMethodHandler = new BlockingTargetMethodHandler(
-        this.targetMethodDefinition,
+        methodDefinition,
         this.encoder,
         Collections.singletonList(this.interceptor),
         this.client,
@@ -293,8 +299,9 @@ class AbstractTargetMethodHandlerTest {
         .readTimeout(1000)
         .body(1);
 
+    TargetMethodDefinition methodDefinition = this.targetMethodDefinition.build();
     TargetMethodHandler targetMethodHandler = new BlockingTargetMethodHandler(
-        this.targetMethodDefinition,
+        methodDefinition,
         this.encoder,
         Collections.singletonList(this.interceptor),
         this.client,
@@ -318,8 +325,9 @@ class AbstractTargetMethodHandlerTest {
         .method(HttpMethod.GET)
         .templateParameter(0, new SimpleTemplateParameter("name"));
 
+    TargetMethodDefinition methodDefinition = this.targetMethodDefinition.build();
     TargetMethodHandler targetMethodHandler = new BlockingTargetMethodHandler(
-        this.targetMethodDefinition,
+        methodDefinition,
         this.encoder,
         Collections.singletonList(this.interceptor),
         this.client,
@@ -348,8 +356,9 @@ class AbstractTargetMethodHandlerTest {
         .body(1);
 
     ExceptionHandler exceptionHandler = spy(new RethrowExceptionHandler());
+    TargetMethodDefinition methodDefinition = this.targetMethodDefinition.build();
     TargetMethodHandler targetMethodHandler = new BlockingTargetMethodHandler(
-        this.targetMethodDefinition,
+        methodDefinition,
         this.encoder,
         Collections.singletonList(this.interceptor),
         this.client,

--- a/core/src/test/java/feign/impl/AsyncTargetMethodHandlerTest.java
+++ b/core/src/test/java/feign/impl/AsyncTargetMethodHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/impl/BlockingTargetMethodHandlerTest.java
+++ b/core/src/test/java/feign/impl/BlockingTargetMethodHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,14 +59,15 @@ class BlockingTargetMethodHandlerTest {
   @Test
   void usingDefaultExecutor_willUseTheCallingThread() throws Throwable {
     AuditingExecutor executor = new AuditingExecutor();
-    TargetMethodDefinition methodDefinition = new TargetMethodDefinition(
+    TargetMethodDefinition.Builder builder = TargetMethodDefinition.builder(
         new UriTarget<>(Blog.class, "https://www.example.com"));
-    TargetMethodHandler blockingHandler = new BlockingTargetMethodHandler(methodDefinition, encoder,
-        Collections.emptyList(), client, decoder, exceptionHandler, executor, logger, retry);
-
-    methodDefinition.returnType(void.class)
+    builder.returnType(void.class)
         .uri("/resources/{name}")
         .method(HttpMethod.GET);
+
+    TargetMethodDefinition methodDefinition = builder.build();
+    TargetMethodHandler blockingHandler = new BlockingTargetMethodHandler(methodDefinition, encoder,
+        Collections.emptyList(), client, decoder, exceptionHandler, executor, logger, retry);
 
     /* get the current thread id */
     long currentThread = Thread.currentThread().getId();

--- a/core/src/test/java/feign/impl/TypeDrivenMethodHandlerFactoryTest.java
+++ b/core/src/test/java/feign/impl/TypeDrivenMethodHandlerFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ class TypeDrivenMethodHandlerFactoryTest {
 
   private FeignConfiguration feignConfiguration;
 
-  private TargetMethodDefinition targetMethodDefinition;
+  private TargetMethodDefinition.Builder targetMethodDefinition;
 
   private TypeDrivenMethodHandlerFactory methodHandlerFactory;
 
@@ -68,30 +68,33 @@ class TypeDrivenMethodHandlerFactoryTest {
   @Test
   void createsBlockingHandler_byDefault() {
     this.targetMethodDefinition =
-        new TargetMethodDefinition(new UriTarget<>(Blog.class, "https://www.example.com"));
+        TargetMethodDefinition.builder(new UriTarget<>(Blog.class, "https://www.example.com"));
     targetMethodDefinition.returnType(String.class);
     TargetMethodHandler targetMethodHandler =
-        this.methodHandlerFactory.create(this.targetMethodDefinition, this.feignConfiguration);
+        this.methodHandlerFactory
+            .create(this.targetMethodDefinition.build(), this.feignConfiguration);
     assertThat(targetMethodHandler).isInstanceOf(BlockingTargetMethodHandler.class);
   }
 
   @Test
   void createsAsyncHandler_whenReturnType_isFuture() {
     this.targetMethodDefinition =
-        new TargetMethodDefinition(new UriTarget<>(Blog.class, "https://www.example.com"));
+        TargetMethodDefinition.builder(new UriTarget<>(Blog.class, "https://www.example.com"));
     targetMethodDefinition.returnType(Future.class);
     TargetMethodHandler targetMethodHandler =
-        this.methodHandlerFactory.create(this.targetMethodDefinition, this.feignConfiguration);
+        this.methodHandlerFactory
+            .create(this.targetMethodDefinition.build(), this.feignConfiguration);
     assertThat(targetMethodHandler).isInstanceOf(AsyncTargetMethodHandler.class);
   }
 
   @Test
   void createsAsyncHandler_whenReturnType_isCompletableFuture() {
     this.targetMethodDefinition =
-        new TargetMethodDefinition(new UriTarget<>(Blog.class, "https://www.example.com"));
+        TargetMethodDefinition.builder(new UriTarget<>(Blog.class, "https://www.example.com"));
     targetMethodDefinition.returnType(CompletableFuture.class);
     TargetMethodHandler targetMethodHandler =
-        this.methodHandlerFactory.create(this.targetMethodDefinition, this.feignConfiguration);
+        this.methodHandlerFactory
+            .create(this.targetMethodDefinition.build(), this.feignConfiguration);
     assertThat(targetMethodHandler).isInstanceOf(AsyncTargetMethodHandler.class);
   }
 

--- a/core/src/test/java/feign/impl/UriTargetTest.java
+++ b/core/src/test/java/feign/impl/UriTargetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/impl/type/TypeDefinitionFactoryTest.java
+++ b/core/src/test/java/feign/impl/type/TypeDefinitionFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/logging/SimpleLoggerTest.java
+++ b/core/src/test/java/feign/logging/SimpleLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/proxy/ProxyTargetTest.java
+++ b/core/src/test/java/feign/proxy/ProxyTargetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,14 +47,16 @@ class ProxyTargetTest {
   @Mock
   private TargetMethodHandler targetMethodHandler;
 
-  private ProxyTarget target;
+  private ProxyTarget<?> target;
 
   @SuppressWarnings("unchecked")
   @BeforeEach
   void setUp() {
     Target<?> uriTarget = new UriTarget<>(ProxyInterface.class, "https://www.example.com");
-    TargetMethodDefinition targetMethodDefinition = new TargetMethodDefinition(uriTarget);
-    targetMethodDefinition.name("test");
+    TargetMethodDefinition targetMethodDefinition =
+        TargetMethodDefinition.builder(uriTarget)
+            .name("test")
+            .build();
 
     when(this.feignConfiguration.getTarget()).thenReturn((Target<Object>) uriTarget);
     when(this.targetMethodHandlerFactory.create(any(TargetMethodDefinition.class),

--- a/core/src/test/java/feign/retry/BackoffRetryIntervalTest.java
+++ b/core/src/test/java/feign/retry/BackoffRetryIntervalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/retry/ConditionalRetryBuilderTest.java
+++ b/core/src/test/java/feign/retry/ConditionalRetryBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/retry/ConditionalRetryTest.java
+++ b/core/src/test/java/feign/retry/ConditionalRetryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/retry/ExceptionConditionTest.java
+++ b/core/src/test/java/feign/retry/ExceptionConditionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/retry/NoRetryTest.java
+++ b/core/src/test/java/feign/retry/NoRetryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/retry/RetryAfterHeaderIntervalTest.java
+++ b/core/src/test/java/feign/retry/RetryAfterHeaderIntervalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/retry/RetryConditionTest.java
+++ b/core/src/test/java/feign/retry/RetryConditionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/retry/StatusCodeConditionTest.java
+++ b/core/src/test/java/feign/retry/StatusCodeConditionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/support/AuditingExecutor.java
+++ b/core/src/test/java/feign/support/AuditingExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/template/ExpressionsTest.java
+++ b/core/src/test/java/feign/template/ExpressionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/template/UriTemplateTckTests.java
+++ b/core/src/test/java/feign/template/UriTemplateTckTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/template/UriTemplateTest.java
+++ b/core/src/test/java/feign/template/UriTemplateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/template/UriUtilsTest.java
+++ b/core/src/test/java/feign/template/UriUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/template/expander/BeanExpanderTest.java
+++ b/core/src/test/java/feign/template/expander/BeanExpanderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/template/expander/CachingExpanderRegistryTest.java
+++ b/core/src/test/java/feign/template/expander/CachingExpanderRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/template/expander/DefaultExpanderTest.java
+++ b/core/src/test/java/feign/template/expander/DefaultExpanderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/template/expander/ExpanderUtilsTest.java
+++ b/core/src/test/java/feign/template/expander/ExpanderUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/template/tck/TestCase.java
+++ b/core/src/test/java/feign/template/tck/TestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/template/tck/TestExamples.java
+++ b/core/src/test/java/feign/template/tck/TestExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/feign/template/tck/TestGroup.java
+++ b/core/src/test/java/feign/template/tck/TestGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 OpenFeign Contributors
+ * Copyright 2019-2020 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2019 OpenFeign Contributors
+    Copyright 2019-2020 OpenFeign Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
   <artifactId>feignx</artifactId>
   <packaging>pom</packaging>
   <version>0.0.1-SNAPSHOT</version>
+  <inceptionYear>2019</inceptionYear>
   <modules>
     <module>core</module>
     <module>tests</module>
@@ -49,6 +50,11 @@
         <groupId>javax.annotation</groupId>
         <artifactId>javax.annotation-api</artifactId>
         <version>1.3.2</version>
+      </dependency>
+      <dependency>
+        <groupId>net.jcip</groupId>
+        <artifactId>jcip-annotations</artifactId>
+        <version>1.0</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
@@ -271,16 +277,16 @@
           <groupId>de.qaware.maven</groupId>
           <artifactId>go-offline-maven-plugin</artifactId>
           <version>1.1.0</version>
-            <configuration>
-              <dynamicDependencies>
-                <DynamicDependency>
-                  <groupId>org.apache.maven.surefire</groupId>
-                  <artifactId>surefire-junit-platform</artifactId>
-                  <version>2.22.2</version>
-                  <repositoryType>PLUGIN</repositoryType>
-                </DynamicDependency>
-              </dynamicDependencies>
-            </configuration>
+          <configuration>
+            <dynamicDependencies>
+              <DynamicDependency>
+                <groupId>org.apache.maven.surefire</groupId>
+                <artifactId>surefire-junit-platform</artifactId>
+                <version>2.22.2</version>
+                <repositoryType>PLUGIN</repositoryType>
+              </DynamicDependency>
+            </dynamicDependencies>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>com.mycila</groupId>
@@ -292,7 +298,7 @@
               <headerDefinition>${feign.basedir}/src/resources/header-definition.xml
               </headerDefinition>
             </headerDefinitions>
-            <header>NOTICE</header>
+            <header>${feign.basedir}/src/resources/NOTICE</header>
             <excludes>
               <exclude>mvnw**</exclude>
               <exclude>**/LICENSE</exclude>
@@ -307,6 +313,13 @@
             </excludes>
             <strictCheck>true</strictCheck>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>com.mycila</groupId>
+              <artifactId>license-maven-plugin-git</artifactId>
+              <version>3.0</version>
+            </dependency>
+          </dependencies>
           <executions>
             <execution>
               <phase>validate</phase>
@@ -323,8 +336,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <release>11</release>
         </configuration>
       </plugin>
       <plugin>

--- a/src/resources/NOTICE
+++ b/src/resources/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2019-2020 OpenFeign Contributors
+Copyright ${license.git.copyrightYears} OpenFeign Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2019 OpenFeign Contributors
+    Copyright 2019-2020 OpenFeign Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
This change updates how `TargetMethodMetadata` instances are created by replacing
the dubious copy constructor and in-place updates with a thread-safe
builder that produces immutable instances.

This change also updates all the license headers.