### PR TITLE
Refactor Interceptor into Function and introduce RequestEntity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ defaults: &defaults
 
 version: 2.1
 orbs:
-  codecov: codecov/codecov@1.1.3
+  codecov: codecov/codecov@1.1.1
 jobs:
   build:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ defaults: &defaults
 
 version: 2.1
 orbs:
-  codecov: codecov/codecov@1.0.4
+  codecov: codecov/codecov@1.1.3
 jobs:
   build:
     <<: *defaults

--- a/core/src/main/java/feign/RequestEncoder.java
+++ b/core/src/main/java/feign/RequestEncoder.java
@@ -19,11 +19,19 @@ package feign;
 import feign.http.RequestSpecification;
 
 /**
- * Consumer responsible for encoding the provided object for use on the Request.
+ * Prepares a {@link RequestEntity} for use.
  */
 @FunctionalInterface
 public interface RequestEncoder {
 
-  void apply(Object content, RequestSpecification requestSpecification);
+  /**
+   * Encode the request content for use.  May return {@code null} if the entity should be
+   * ignored.
+   *
+   * @param content to be encoded.
+   * @param requestSpecification containing the current {@link RequestSpecification}.
+   * @return a {@link RequestEntity} instance, or {@code null}.
+   */
+  RequestEntity apply(Object content, RequestSpecification requestSpecification);
 
 }

--- a/core/src/main/java/feign/RequestEntity.java
+++ b/core/src/main/java/feign/RequestEntity.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019-2020 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign;
+
+import java.nio.charset.Charset;
+import java.util.Optional;
+
+/**
+ * Represents the content of a {@link Request}.
+ */
+public interface RequestEntity {
+
+  /**
+   * Character Set this entity is encoded in.
+   *
+   * @return the entity {@link Charset}.
+   */
+  Optional<Charset> getCharset();
+
+  /**
+   * Length of the entity data.
+   *
+   * @return entity data length.
+   */
+  int getContentLength();
+
+  /**
+   * Content Type of the entity.
+   *
+   * @return String representation of a MIME-Type or any other acceptable Content Type.
+   */
+  String getContentType();
+
+  /**
+   * Entity Data.
+   *
+   * @return entity data.
+   */
+  byte[] getData();
+}

--- a/core/src/main/java/feign/RequestInterceptor.java
+++ b/core/src/main/java/feign/RequestInterceptor.java
@@ -17,11 +17,15 @@
 package feign;
 
 import feign.http.RequestSpecification;
-import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
- * Consumer that can be used to modify a Request before being processed.
+ * Function used to act on a {@link RequestSpecification} during request processing.  It is possible
+ * to return an entirely new {@link RequestSpecification} from this component.
  */
-public interface RequestInterceptor extends Consumer<RequestSpecification> {
+public interface RequestInterceptor extends Function<RequestSpecification, RequestSpecification> {
 
+  static RequestInterceptor identity() {
+    return (t) -> t;
+  }
 }

--- a/core/src/main/java/feign/encoder/StringEncoder.java
+++ b/core/src/main/java/feign/encoder/StringEncoder.java
@@ -19,9 +19,6 @@ package feign.encoder;
 import feign.RequestEncoder;
 import feign.RequestEntity;
 import feign.http.RequestSpecification;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.Optional;
 
 /**
  * HttpRequest Encoder that encodes the request content as a String.  This implementation uses
@@ -32,29 +29,9 @@ public class StringEncoder implements RequestEncoder {
   @Override
   public RequestEntity apply(Object content, RequestSpecification requestSpecification) {
     if (content != null) {
-      /* use the content objects toString() method to populate the request */
-      return new RequestEntity() {
-        @Override
-        public Optional<Charset> getCharset() {
-          return Optional.of(StandardCharsets.UTF_8);
-        }
-
-        @Override
-        public int getContentLength() {
-          return 0;
-        }
-
-        @Override
-        public String getContentType() {
-          return null;
-        }
-
-        @Override
-        public byte[] getData() {
-          return content.toString().getBytes(StandardCharsets.UTF_8);
-        }
-      };
+      return new StringRequestEntity(content.toString());
     }
     return null;
   }
+
 }

--- a/core/src/main/java/feign/encoder/StringEncoder.java
+++ b/core/src/main/java/feign/encoder/StringEncoder.java
@@ -17,8 +17,11 @@
 package feign.encoder;
 
 import feign.RequestEncoder;
+import feign.RequestEntity;
 import feign.http.RequestSpecification;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 
 /**
  * HttpRequest Encoder that encodes the request content as a String.  This implementation uses
@@ -27,10 +30,31 @@ import java.nio.charset.StandardCharsets;
 public class StringEncoder implements RequestEncoder {
 
   @Override
-  public void apply(Object content, RequestSpecification requestSpecification) {
+  public RequestEntity apply(Object content, RequestSpecification requestSpecification) {
     if (content != null) {
       /* use the content objects toString() method to populate the request */
-      requestSpecification.content(content.toString().getBytes(StandardCharsets.UTF_8));
+      return new RequestEntity() {
+        @Override
+        public Optional<Charset> getCharset() {
+          return Optional.of(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public int getContentLength() {
+          return 0;
+        }
+
+        @Override
+        public String getContentType() {
+          return null;
+        }
+
+        @Override
+        public byte[] getData() {
+          return content.toString().getBytes(StandardCharsets.UTF_8);
+        }
+      };
     }
+    return null;
   }
 }

--- a/core/src/main/java/feign/encoder/StringRequestEntity.java
+++ b/core/src/main/java/feign/encoder/StringRequestEntity.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019-2020 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.encoder;
+
+import feign.RequestEntity;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Simple Request Entity backed by a String.
+ */
+public class StringRequestEntity implements RequestEntity {
+
+  public static final String TEXT_PLAIN = "text/plain";
+  private final byte[] data;
+  private final int length;
+  private final Charset charset = StandardCharsets.UTF_8;
+
+  public StringRequestEntity(String content) {
+    this.data = content.getBytes(StandardCharsets.UTF_8);
+    this.length = data.length;
+  }
+
+  @Override
+  public Optional<Charset> getCharset() {
+    return Optional.of(this.charset);
+  }
+
+  @Override
+  public int getContentLength() {
+    return this.length;
+  }
+
+  @Override
+  public String getContentType() {
+    return TEXT_PLAIN;
+  }
+
+  @Override
+  public byte[] getData() {
+    return Arrays.copyOf(this.data, this.data.length);
+  }
+}

--- a/core/src/test/java/feign/FeignTests.java
+++ b/core/src/test/java/feign/FeignTests.java
@@ -255,7 +255,10 @@ class FeignTests {
         .encoder(new StringEncoder())
         .decoder(new StringDecoder())
         .exceptionHandler(exceptionHandler)
-        .interceptor(requestSpecification -> System.out.println("intercept"))
+        .interceptor(requestSpecification -> {
+          System.out.println("intercept");
+          return requestSpecification;
+        })
         .executor(Executors.newSingleThreadExecutor())
         .logger(logger)
         .retry(retry)

--- a/core/src/test/java/feign/encoder/StringEncoderTest.java
+++ b/core/src/test/java/feign/encoder/StringEncoderTest.java
@@ -16,13 +16,11 @@
 
 package feign.encoder;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 import feign.RequestEncoder;
+import feign.RequestEntity;
 import feign.http.RequestSpecification;
 import org.junit.jupiter.api.Test;
 
@@ -32,15 +30,16 @@ class StringEncoderTest {
   void apply_toString() {
     RequestEncoder encoder = new StringEncoder();
     RequestSpecification requestSpecification = mock(RequestSpecification.class);
-    encoder.apply("content", requestSpecification);
-    verify(requestSpecification, times(1)).content(any(byte[].class));
+    RequestEntity entity = encoder.apply("content", requestSpecification);
+    assertThat(entity).isNotNull();
+    assertThat(entity.getData()).isNotEmpty();
   }
 
   @Test
   void apply_withNullSkips() {
     RequestEncoder encoder = new StringEncoder();
     RequestSpecification requestSpecification = mock(RequestSpecification.class);
-    encoder.apply(null, requestSpecification);
-    verifyZeroInteractions(requestSpecification);
+    RequestEntity entity = encoder.apply(null, requestSpecification);
+    assertThat(entity).isNull();
   }
 }

--- a/core/src/test/java/feign/encoder/StringRequestEntityTest.java
+++ b/core/src/test/java/feign/encoder/StringRequestEntityTest.java
@@ -35,7 +35,7 @@ class StringRequestEntityTest {
     StringRequestEntity requestEntity = new StringRequestEntity(content);
     assertThat(requestEntity).isNotNull();
     assertThat(requestEntity.getCharset()).isPresent()
-        .isEqualTo(StandardCharsets.UTF_8);
+        .hasValue(StandardCharsets.UTF_8);
     assertThat(requestEntity.getContentType()).isNotEmpty()
         .isEqualToIgnoringCase(StringRequestEntity.TEXT_PLAIN);
     assertThat(requestEntity.getData()).isNotEmpty()

--- a/core/src/test/java/feign/encoder/StringRequestEntityTest.java
+++ b/core/src/test/java/feign/encoder/StringRequestEntityTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019-2020 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.encoder;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit Test for StringRequestEntity.
+ */
+class StringRequestEntityTest {
+
+  @Test
+  void canCreate() {
+    final String content = "content";
+    final int contentLength = content.getBytes(StandardCharsets.UTF_8).length;
+
+    StringRequestEntity requestEntity = new StringRequestEntity(content);
+    assertThat(requestEntity).isNotNull();
+    assertThat(requestEntity.getCharset()).isPresent()
+        .isEqualTo(StandardCharsets.UTF_8);
+    assertThat(requestEntity.getContentType()).isNotEmpty()
+        .isEqualToIgnoringCase(StringRequestEntity.TEXT_PLAIN);
+    assertThat(requestEntity.getData()).isNotEmpty()
+        .hasSize(contentLength);
+    assertThat(requestEntity.getContentLength()).isEqualTo(contentLength);
+  }
+}

--- a/core/src/test/java/feign/impl/AsyncTargetMethodHandlerTest.java
+++ b/core/src/test/java/feign/impl/AsyncTargetMethodHandlerTest.java
@@ -71,7 +71,7 @@ class AsyncTargetMethodHandlerTest {
   private ResponseDecoder decoder;
 
   @Spy
-  private ExceptionHandler exceptionHandler = new RethrowExceptionHandler();
+  private final ExceptionHandler exceptionHandler = new RethrowExceptionHandler();
 
   @Mock
   private Logger logger;
@@ -82,14 +82,15 @@ class AsyncTargetMethodHandlerTest {
   @Captor
   private ArgumentCaptor<Class<?>> classArgumentCaptor;
 
-  private Contract contract = new FeignContract();
+  private final Contract contract = new FeignContract();
 
   private AsyncTargetMethodHandler methodHandler;
 
-  private Retry retry = new NoRetry();
+  private final Retry retry = new NoRetry();
 
-  private Executor executor = Executors.newFixedThreadPool(10);
+  private final Executor executor = Executors.newFixedThreadPool(10);
 
+  @SuppressWarnings("OptionalGetWithoutIsPresent")
   @BeforeEach
   void setUp() {
     Collection<TargetMethodDefinition> methodDefinitions =
@@ -143,7 +144,7 @@ class AsyncTargetMethodHandlerTest {
     verify(this.exceptionHandler, times(1)).apply(any(Throwable.class));
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "OptionalGetWithoutIsPresent"})
   @Test
   void methodNotHandled_returnsNull() {
     Collection<TargetMethodDefinition> methodDefinitions =
@@ -175,7 +176,7 @@ class AsyncTargetMethodHandlerTest {
     verify(mockHandler, times(1)).apply(any(Throwable.class));
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "OptionalGetWithoutIsPresent"})
   @Test
   void usingMultiThreadedExecutor_willExecuteOnOtherThreads() throws Throwable {
     AuditingExecutor executor = new AuditingExecutor(this.executor);
@@ -191,13 +192,13 @@ class AsyncTargetMethodHandlerTest {
 
     /* execute the request */
     CompletableFuture<Object> result =
-        (CompletableFuture) asyncTargetMethodHandler.execute(new Object[]{});
+        (CompletableFuture<Object>) asyncTargetMethodHandler.execute(new Object[]{});
     result.get();
 
     /* make sure that the executor used different threads */
     assertThat(executor.getThreads()).doesNotHaveDuplicates()
         .hasSizeGreaterThan(1).contains(currentThread);
-    assertThat(executor.getExecutionCount()).isEqualTo(5);
+    assertThat(executor.getExecutionCount()).isEqualTo(6);
   }
 
   interface Blog {

--- a/core/src/test/java/feign/impl/BlockingTargetMethodHandlerTest.java
+++ b/core/src/test/java/feign/impl/BlockingTargetMethodHandlerTest.java
@@ -54,7 +54,7 @@ class BlockingTargetMethodHandlerTest {
   @Mock
   private Logger logger;
 
-  private Retry retry = new NoRetry();
+  private final Retry retry = new NoRetry();
 
   @Test
   void usingDefaultExecutor_willUseTheCallingThread() throws Throwable {
@@ -77,7 +77,7 @@ class BlockingTargetMethodHandlerTest {
 
     /* make sure that the executor used the current thread only */
     assertThat(executor.getThreads()).containsOnly(currentThread);
-    assertThat(executor.getExecutionCount()).isEqualTo(5);
+    assertThat(executor.getExecutionCount()).isEqualTo(6);
   }
 
   interface Blog {


### PR DESCRIPTION
This changes changes `RequestInterceptor` from a `Consumer` to a
`Function`, to simplify Request Specification management during method execution,
specifically during Asynchronous or Reactive execution.  Modifying
the `RequestSpecification` through side-effects is difficult to reason over
and is one of the areas that existing Feign struggles with.

Additionally, `RequestEncoder` has been modified to return a `RequestEntity` to
more closely match current Feign and to make updating a Request body, content type,
content length, and charset more explicit.

