### PR TITLE
Add HttpHeaders collection and update Request to support RequestEntity

### DIFF
--- a/core/src/main/java/feign/Header.java
+++ b/core/src/main/java/feign/Header.java
@@ -43,4 +43,9 @@ public interface Header {
    * @param value to add.
    */
   void value(String value);
+
+  /**
+   * Clear the Header values.
+   */
+  void clear();
 }

--- a/core/src/main/java/feign/Request.java
+++ b/core/src/main/java/feign/Request.java
@@ -18,7 +18,7 @@ package feign;
 
 import feign.http.HttpMethod;
 import java.net.URI;
-import java.util.List;
+import java.util.Collection;
 
 /**
  * Information about a Request to be made.
@@ -47,6 +47,13 @@ public interface Request {
   int contentLength();
 
   /**
+   * MIME Type or other equivalent content type.  May be {@code null}
+   *
+   * @return request content type.
+   */
+  String contentType();
+
+  /**
    * Http Method for this request.
    *
    * @return http method.
@@ -58,7 +65,7 @@ public interface Request {
    *
    * @return request headers.
    */
-  List<Header> headers();
+  Collection<Header> headers();
 
   /**
    * Options for this request.

--- a/core/src/main/java/feign/http/HttpHeader.java
+++ b/core/src/main/java/feign/http/HttpHeader.java
@@ -90,17 +90,6 @@ public class HttpHeader implements Header {
   }
 
   /**
-   * Add All of the provided values to the header.
-   *
-   * @param values to be added.
-   * @throws IllegalArgumentException if the value is {@literal null}
-   * @throws IllegalStateException if the header name does not support multiple values.
-   */
-  void values(Collection<String> values) {
-    values.forEach(this::value);
-  }
-
-  /**
    * The values for this header.
    *
    * @return a read-only collection containing the values.

--- a/core/src/main/java/feign/http/HttpHeader.java
+++ b/core/src/main/java/feign/http/HttpHeader.java
@@ -90,6 +90,17 @@ public class HttpHeader implements Header {
   }
 
   /**
+   * Add All of the provided values to the header.
+   *
+   * @param values to be added.
+   * @throws IllegalArgumentException if the value is {@literal null}
+   * @throws IllegalStateException if the header name does not support multiple values.
+   */
+  void values(Collection<String> values) {
+    values.forEach(this::value);
+  }
+
+  /**
    * The values for this header.
    *
    * @return a read-only collection containing the values.

--- a/core/src/main/java/feign/http/HttpHeaders.java
+++ b/core/src/main/java/feign/http/HttpHeaders.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2019-2020 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.http;
+
+import feign.Header;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+public class HttpHeaders implements Iterable<Header> {
+
+  private static final String CONTENT_TYPE = "Content-Type";
+  private static final String CONTENT_LENGTH = "Content-Length";
+
+  /* cached map to our headers for quick lookup */
+  private final Map<String, Header> headers = new ConcurrentHashMap<>();
+
+  /**
+   * Create a new set of {@link HttpHeaders}.
+   */
+  public HttpHeaders() {
+    super();
+  }
+
+  /**
+   * Return a Stream backed by the underlying collection.
+   *
+   * @return Stream of HttpHeaders.
+   */
+  public Stream<Header> stream() {
+    return this.headers.values().stream();
+  }
+
+  /**
+   * Add the {@link HttpHeader} onto the Collection.
+   *
+   * @param header to add.
+   */
+  public void add(final Header header) {
+    this.headers.compute(header.name(), (key, existing) -> {
+      if (existing == null) {
+        /* use the new header */
+        return header;
+      }
+
+      /* merge this header with the other headers */
+      header.values().forEach(existing::value);
+      return existing;
+    });
+  }
+
+  /**
+   * Remove the {@link HttpHeader}.
+   *
+   * @param header to remove.
+   */
+  public void remove(final HttpHeader header) {
+    this.headers.remove(header.name());
+  }
+
+  /**
+   * Retrieve a HttpHeader, by name.
+   *
+   * @param name of the header.
+   * @return the {@link HttpHeader} for this name, or {@code null} if not set.
+   */
+  public Header get(String name) {
+    return this.headers.get(name);
+  }
+
+  /**
+   * Set the Content-Type Header.
+   *
+   * @param contentType to use.
+   */
+  public void setContentType(final String contentType) {
+    this.headers.compute(CONTENT_TYPE, (key, existing) -> {
+      if (existing != null) {
+        existing.clear();
+        existing.value(contentType);
+      } else {
+        existing = new HttpHeader(CONTENT_TYPE, List.of(contentType));
+      }
+      return existing;
+    });
+  }
+
+  /**
+   * Set the Content-Length Header.
+   *
+   * @param contentLength of the request.
+   */
+  public void setContentLength(final int contentLength) {
+    this.headers.compute(CONTENT_LENGTH, (key, existing) -> {
+      if (existing != null) {
+        existing.clear();
+        existing.value(String.valueOf(contentLength));
+      } else {
+        existing = new HttpHeader(CONTENT_LENGTH, List.of(String.valueOf(contentLength)));
+      }
+      return existing;
+    });
+  }
+
+  /**
+   * The backing Collection.
+   *
+   * @return the collection of header values.
+   */
+  public Collection<Header> values() {
+    return Set.copyOf(this.headers.values());
+  }
+
+  /**
+   * Return an Iterator backed by the underlying collection.
+   *
+   * @return a new Iterator instance.
+   */
+  @Override
+  public Iterator<Header> iterator() {
+    return this.headers.values().iterator();
+  }
+}

--- a/core/src/main/java/feign/http/RequestSpecification.java
+++ b/core/src/main/java/feign/http/RequestSpecification.java
@@ -18,6 +18,7 @@ package feign.http;
 
 import feign.Header;
 import feign.Request;
+import feign.RequestEntity;
 import feign.RequestOptions;
 import feign.support.Assert;
 import feign.support.StringUtils;
@@ -40,7 +41,7 @@ public class RequestSpecification {
   private URI uri;
   private final Map<String, Header> headers = new LinkedHashMap<>();
   private final Map<String, List<String>> parameters = new LinkedHashMap<>();
-  private byte[] content;
+  private RequestEntity content;
   private long connectTimeout;
   private TimeUnit connectTimeoutUnit;
   private long readTimeout;
@@ -152,7 +153,7 @@ public class RequestSpecification {
    * @param content to include in the HttpRequest body.
    * @return the reference chain.
    */
-  public RequestSpecification content(byte[] content) {
+  public RequestSpecification content(RequestEntity content) {
     this.content = content;
     return this;
   }

--- a/core/src/main/java/feign/impl/AbstractTargetMethodHandler.java
+++ b/core/src/main/java/feign/impl/AbstractTargetMethodHandler.java
@@ -211,7 +211,7 @@ public abstract class AbstractTargetMethodHandler implements TargetMethodHandler
           log.debug("Encoding Request Body: {}", body.getClass().getSimpleName());
           RequestEntity entity = this.encoder.apply(body, requestSpecification);
           if (entity != null) {
-            requestSpecification.content(entity.getData());
+            requestSpecification.content(entity);
           }
         });
     return requestSpecification;

--- a/core/src/test/java/feign/assertions/AbstractHttpRequestAssert.java
+++ b/core/src/test/java/feign/assertions/AbstractHttpRequestAssert.java
@@ -16,6 +16,7 @@
 
 package feign.assertions;
 
+import feign.Header;
 import feign.http.HttpHeader;
 import feign.http.HttpRequest;
 import java.util.Collection;
@@ -60,8 +61,9 @@ public abstract class AbstractHttpRequestAssert<S extends AbstractHttpRequestAss
     }
 
     // check with standard error message (use overridingErrorMessage before contains to set your own message).
-    Assertions.assertThat(org.assertj.core.util.introspection.FieldSupport.EXTRACTION
-        .fieldValue("content", byte[].class, actual)).contains(content);
+    Assertions.assertThat(org.assertj.core.util.introspection.PropertySupport
+        .propertyValueOf("content", actual, byte[].class)).contains(content);
+
 
     // return the current assertion for method chaining
     return myself;
@@ -151,7 +153,7 @@ public abstract class AbstractHttpRequestAssert<S extends AbstractHttpRequestAss
    * @throws AssertionError if the actual HttpRequest's headers does not contain all given
    * HttpHeader elements.
    */
-  public S hasHeaders(java.util.Collection<? extends HttpHeader> headers) {
+  public S hasHeaders(java.util.Collection<? extends Header> headers) {
     // check that actual HttpResponse we want to make assertions on is not null.
     isNotNull();
 
@@ -162,7 +164,7 @@ public abstract class AbstractHttpRequestAssert<S extends AbstractHttpRequestAss
     }
 
     // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
-    Iterables.instance().assertContains(info, org.assertj.core.util.introspection.FieldSupport.EXTRACTION.fieldValue("headers", java.util.List.class, actual), headers.toArray());
+    Iterables.instance().assertContains(info, org.assertj.core.util.introspection.PropertySupport.propertyValueOf("headers", actual, java.util.List.class), headers.toArray());
 
     // return the current assertion for method chaining
     return myself;
@@ -210,7 +212,7 @@ public abstract class AbstractHttpRequestAssert<S extends AbstractHttpRequestAss
     if (headers == null) failWithMessage("Expecting headers parameter not to be null.");
 
     // check with standard error message (use overridingErrorMessage before contains to set your own message).
-    Iterables.instance().assertDoesNotContain(info, org.assertj.core.util.introspection.FieldSupport.EXTRACTION.fieldValue("headers", java.util.List.class, actual), headers);
+    Iterables.instance().assertDoesNotContain(info, org.assertj.core.util.introspection.PropertySupport.propertyValueOf("headers", actual, java.util.List.class), headers);
 
     // return the current assertion for method chaining
     return myself;

--- a/core/src/test/java/feign/http/HttpHeadersTest.java
+++ b/core/src/test/java/feign/http/HttpHeadersTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019-2020 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import feign.Header;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class HttpHeadersTest {
+
+  private HttpHeaders headers;
+
+  @BeforeEach
+  void setUp() {
+    this.headers = new HttpHeaders();
+  }
+
+  @Test
+  void canAdd() {
+    HttpHeader header = new HttpHeader("simple", List.of("value"));
+    this.headers.add(header);
+    assertThat(this.headers).contains(header);
+    assertThat(this.headers.values()).isNotEmpty().hasSize(1);
+  }
+
+  @Test
+  void canRemove() {
+    HttpHeader header = new HttpHeader("simple", List.of("value"));
+    this.headers.add(header);
+    assertThat(this.headers).contains(header);
+
+    this.headers.remove(header);
+    assertThat(this.headers).doesNotContain(header);
+  }
+
+  @Test
+  void canAppend() {
+    HttpHeader header = new HttpHeader("Accept", List.of("value"));
+    this.headers.add(header);
+    assertThat(this.headers).contains(header);
+
+    this.headers.add(new HttpHeader("Accept", List.of("another")));
+    assertThat(this.headers).hasSize(1);
+
+    Header simple = this.headers.get("Accept");
+    assertThat(simple).isNotNull();
+    assertThat(simple.values()).hasSize(2)
+        .contains("value", "another");
+  }
+
+  @Test
+  void canIterateAndStream() {
+    this.headers.add(new HttpHeader("simple", List.of("items")));
+    this.headers.add(new HttpHeader("another", List.of("single")));
+
+    assertThat(this.headers.stream()).isNotNull();
+    assertThat(this.headers.iterator()).isNotNull();
+    assertThat(this.headers).isNotEmpty();
+    assertThat(this.headers.stream().count() == 2);
+  }
+
+  @Test
+  void canSetContentType() {
+    this.headers.setContentType("application/json");
+    assertThat(this.headers).contains(
+        new HttpHeader("Content-Type", List.of("application/json")));
+
+    /* calling again should replace the content type */
+    this.headers.setContentType("text/plain");
+    assertThat(this.headers).contains(
+        new HttpHeader("Content-Type", List.of("application/json")))
+        .hasSize(1);
+  }
+
+  @Test
+  void canSetContentLength() {
+    this.headers.setContentLength(100);
+    assertThat(this.headers).contains(
+        new HttpHeader("Content-Length", List.of("100")))
+        .hasSize(1);
+
+    /* calling again should replace */
+    this.headers.setContentLength(10);
+    assertThat(this.headers).contains(
+        new HttpHeader("Content-Length", List.of("10")))
+        .hasSize(1);
+  }
+
+}

--- a/core/src/test/java/feign/http/HttpRequestTest.java
+++ b/core/src/test/java/feign/http/HttpRequestTest.java
@@ -18,6 +18,7 @@ package feign.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import feign.encoder.StringRequestEntity;
 import java.net.URI;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -44,6 +45,15 @@ class HttpRequestTest {
         null,
         null);
     assertThat(request.contentLength()).isZero();
+
+    /* ensure that the content related headers are absent */
+    assertThat(request.headers()).filteredOn(
+        header -> "Content-Type".equalsIgnoreCase(header.name()))
+        .isEmpty();
+
+    assertThat(request.headers()).filteredOn(
+        header -> "Content-Length".equalsIgnoreCase(header.name()))
+        .isEmpty();
   }
 
   @Test
@@ -55,5 +65,25 @@ class HttpRequestTest {
         null,
         null);
     assertThat(request.toString()).isNotEmpty();
+  }
+
+  @Test
+  void contentType_isSet_WhenEntityPresent() {
+    HttpRequest request = new HttpRequest(
+        URI.create("https://api.example.com"),
+        HttpMethod.POST,
+        Collections.emptyList(),
+        null,
+        new StringRequestEntity("content"));
+    assertThat(request.content()).isNotNull();
+    assertThat(request.contentLength()).isNotZero();
+    assertThat(request.contentType()).isEqualToIgnoringCase("text/plain");
+    assertThat(request.headers()).filteredOn(
+        header -> "Content-Type".equalsIgnoreCase(header.name()))
+        .isNotEmpty();
+
+    assertThat(request.headers()).filteredOn(
+        header -> "Content-Length".equalsIgnoreCase(header.name()))
+        .isNotEmpty();
   }
 }

--- a/core/src/test/java/feign/http/RequestSpecificationTest.java
+++ b/core/src/test/java/feign/http/RequestSpecificationTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import feign.Header;
 import feign.Request;
 import feign.RequestOptions;
+import feign.encoder.StringRequestEntity;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -42,7 +43,7 @@ class RequestSpecificationTest {
         .followRedirects(true)
         .readTimeout(2, TimeUnit.SECONDS)
         .connectTimeout(1, TimeUnit.SECONDS)
-        .content("data".getBytes(StandardCharsets.UTF_8))
+        .content(new StringRequestEntity("data"))
         .build();
     assertThat(request).isInstanceOf(HttpRequest.class);
 


### PR DESCRIPTION
To simply management of common headers like Content Type and Content Length,
a new `HttpHeaders` collection has been added.  This collection facilitates
the handling of `RequestEntity` objects, which have replaced direct byte
buffers and other techniques for managing request content.

Additional Changes:
* Unit Tests
* Assertion updates