### PR TITLE
Update SimpleLogger and MethodHandler Loggers to be assigned to Target

### DIFF
--- a/core/src/main/java/feign/TargetMethodDefinition.java
+++ b/core/src/main/java/feign/TargetMethodDefinition.java
@@ -182,6 +182,15 @@ public final class TargetMethodDefinition {
   }
 
   /**
+   * Target Type Class name.
+   *
+   * @return the simple name of the Target Class.
+   */
+  public String getTargetType() {
+    return this.target.type().getName();
+  }
+
+  /**
    * Argument Index registered for the value that should be used as the HttpRequest body.
    *
    * @return the request body argument index.

--- a/core/src/main/java/feign/logging/AbstractLogger.java
+++ b/core/src/main/java/feign/logging/AbstractLogger.java
@@ -28,7 +28,6 @@ import java.util.StringJoiner;
 /**
  * Base Logger implementation.
  */
-@SuppressWarnings("WeakerAccess")
 public abstract class AbstractLogger implements Logger {
 
   private final boolean enabled;
@@ -93,7 +92,7 @@ public abstract class AbstractLogger implements Logger {
 
       if (this.responseEnabled) {
         int length = response.contentLength();
-        if (length != 0) {
+        if (length > 0) {
           if (length < 512) {
             try {
               /* this forces us to read the entire response before logging */

--- a/core/src/test/java/feign/FeignTests.java
+++ b/core/src/test/java/feign/FeignTests.java
@@ -114,6 +114,7 @@ class FeignTests {
   @Test
   void createTargetAndExecute() {
     Logger logger = SimpleLogger.builder()
+        .setName(GitHub.class.getName())
         .setEnabled(true)
         .setHeadersEnabled(true)
         .setRequestEnabled(true)

--- a/core/src/test/java/feign/logging/SimpleLoggerTest.java
+++ b/core/src/test/java/feign/logging/SimpleLoggerTest.java
@@ -142,6 +142,20 @@ class SimpleLoggerTest {
   }
 
   @Test
+  void shouldNotLogResponseBody_whenBodyIsZero() throws IOException {
+    SimpleLogger simpleLogger = SimpleLogger.builder()
+        .setEnabled(true)
+        .setResponseEnabled(true)
+        .build();
+
+    Response response = mock(Response.class);
+    when(response.contentLength()).thenReturn(0);
+    simpleLogger.logResponse("test", response);
+    verify(response, times(0)).toByteArray();
+    verify(response, times(0)).headers();
+  }
+
+  @Test
   void shouldLogResponseHeaders_whenEnabled() throws IOException {
     SimpleLogger simpleLogger = SimpleLogger.builder()
         .setEnabled(true)
@@ -176,4 +190,19 @@ class SimpleLoggerTest {
         "test", new RetryContext(3, new IOException("bad"), response));
     verifyZeroInteractions(response);
   }
+
+  @Test
+  void shouldLogException_ifResponseCannotBeRead() throws Exception {
+    SimpleLogger simpleLogger = SimpleLogger.builder()
+        .setEnabled(false)
+        .setResponseEnabled(true)
+        .build();
+
+    Response response = mock(Response.class);
+    when(response.toByteArray()).thenThrow(new IOException("stream closed"));
+    when(response.contentLength()).thenReturn(128);
+    simpleLogger.logResponse("test", response);
+    verify(response, times(1)).toByteArray();
+  }
+
 }


### PR DESCRIPTION
This change updates the SimpleLogger's `log` instance to be assigned
to a user supplied name, allowing users to control what object the
log messages are attributed to.

In addition, `AbstractTargetMethodHandler`'s internal Logger has been
updated to be targeted to the `Target` instead of itself.  This allows
all internal Feign logging during method handling to be attributed to
the Target instance instead of Feign.
