### PR TITLE
GH-57: Adding Annotation Processor Skeleton

### DIFF
--- a/core/src/main/java/feign/FeignTarget.java
+++ b/core/src/main/java/feign/FeignTarget.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019-2021 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares a given interface a Feign {@link feign.Target}.  Used by our annotation processor
+ * to generate target implementations at compile time.
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.CLASS)
+@Documented
+@Inherited
+public @interface FeignTarget {
+
+}

--- a/core/src/main/java/feign/annotation/FeignTargetAnnotationProcessor.java
+++ b/core/src/main/java/feign/annotation/FeignTargetAnnotationProcessor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019-2021 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.annotation;
+
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+
+/**
+ * Annotation Processor for {@link feign.FeignTarget} annotated interfaces.
+ */
+@SupportedAnnotationTypes({"feign.FeignTarget"})
+@SupportedSourceVersion(SourceVersion.RELEASE_11)
+public class FeignTargetAnnotationProcessor extends AbstractProcessor {
+
+  @Override
+  public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+    return false;
+  }
+
+}

--- a/tests/src/main/java/io/openfeign/TestService.java
+++ b/tests/src/main/java/io/openfeign/TestService.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019-2021 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.openfeign;
+
+import feign.FeignTarget;
+import feign.contract.Param;
+import feign.contract.Request;
+import feign.http.HttpMethod;
+import java.util.List;
+
+@FeignTarget
+public interface TestService {
+
+  @Request(method = HttpMethod.GET, value = "/contributors/{repository}")
+  List<String> getContributors(@Param("repository") String repository);
+
+}

--- a/tests/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/tests/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+feign.annotation.FeignTargetAnnotationProcessor


### PR DESCRIPTION
This change introduces the skeleton for our Annotation Processor,
that will allow users to choose between our default runtime target
generator and a compile-time alternative.
