### PR TITLE
GH-57 Delegate Template Parameter creation to Method Handlers

### DIFF
--- a/core/src/main/java/feign/TargetMethodDefinition.java
+++ b/core/src/main/java/feign/TargetMethodDefinition.java
@@ -54,7 +54,7 @@ public final class TargetMethodDefinition {
   private final transient TypeDefinition returnType;
   private final UriTemplate template;
   private final Collection<HttpHeader> headers;
-  private final Map<Integer, TemplateParameter> parameterMap;
+  private final Map<Integer, TargetMethodParameterDefinition> parameterMap;
   private final Integer bodyArgumentIndex;
   private final boolean followRedirects;
   private final long connectTimeout;
@@ -90,7 +90,7 @@ public final class TargetMethodDefinition {
     }
 
     targetMethodDefinition.parameterMap.forEach(
-        builder::templateParameter);
+        builder::parameterDefinition);
     targetMethodDefinition.headers.forEach(builder::header);
 
     /* return the populated builder */
@@ -109,7 +109,7 @@ public final class TargetMethodDefinition {
       UriTemplate template,
       HttpMethod method,
       Collection<HttpHeader> headers,
-      Map<Integer, TemplateParameter> parameterMap,
+      Map<Integer, TargetMethodParameterDefinition> parameterMap,
       Integer bodyArgumentIndex,
       boolean followRedirects,
       long connectTimeout,
@@ -163,12 +163,12 @@ public final class TargetMethodDefinition {
   }
 
   /**
-   * Template Parameter registered at the specified method argument index.
+   * {@link TargetMethodParameterDefinition} registered at the specified method argument index.
    *
    * @param argumentIndex of the parameter.
-   * @return the Template Parameter registered, if one exists.
+   * @return the {@link TargetMethodParameterDefinition} registered, if one exists.
    */
-  public Optional<TemplateParameter> getTemplateParameter(Integer argumentIndex) {
+  public Optional<TargetMethodParameterDefinition> getParameterDefinition(Integer argumentIndex) {
     return Optional.ofNullable(parameterMap.get(argumentIndex));
   }
 
@@ -218,11 +218,11 @@ public final class TargetMethodDefinition {
   }
 
   /**
-   * The Template Parameters registered for this method.
+   * The {@link TargetMethodParameterDefinition}s registered for this method.
    *
    * @return the parameters registered.
    */
-  public Collection<TemplateParameter> getTemplateParameters() {
+  public Collection<TargetMethodParameterDefinition> getParameterDefinitions() {
     return Collections.unmodifiableCollection(this.parameterMap.values());
   }
 
@@ -341,7 +341,8 @@ public final class TargetMethodDefinition {
     private UriTemplate template;
     private HttpMethod method = HttpMethod.GET;
     private final Collection<HttpHeader> headers = new CopyOnWriteArraySet<>();
-    private final Map<Integer, TemplateParameter> parameterMap = new ConcurrentHashMap<>();
+    private final Map<Integer, TargetMethodParameterDefinition> parameterMap =
+        new ConcurrentHashMap<>();
     private Integer bodyArgumentIndex = -1;
     private boolean followRedirects;
     private long connectTimeout = RequestOptions.DEFAULT_CONNECT_TIMEOUT;
@@ -429,15 +430,15 @@ public final class TargetMethodDefinition {
     }
 
     /**
-     * Registers a {@link TemplateParameter} at the method argument index.
+     * Registers a {@link TargetMethodParameterDefinition} at the method argument index.
      *
      * @param argumentIndex in the method signature.
-     * @param templateParameter to register.
+     * @param definition to register.
      * @return the reference chain.
      */
-    public Builder templateParameter(
-        Integer argumentIndex, TemplateParameter templateParameter) {
-      this.parameterMap.put(argumentIndex, templateParameter);
+    public Builder parameterDefinition(
+        Integer argumentIndex, TargetMethodParameterDefinition definition) {
+      this.parameterMap.put(argumentIndex, definition);
       return this;
     }
 

--- a/core/src/main/java/feign/TargetMethodParameterDefinition.java
+++ b/core/src/main/java/feign/TargetMethodParameterDefinition.java
@@ -17,7 +17,6 @@
 package feign;
 
 import feign.support.Assert;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.StringJoiner;
 import net.jcip.annotations.Immutable;
@@ -31,6 +30,7 @@ import net.jcip.annotations.ThreadSafe;
 public class TargetMethodParameterDefinition {
 
   private final String name;
+  private final String type;
   private final Integer index;
   private final String expanderClassName;
 
@@ -41,15 +41,20 @@ public class TargetMethodParameterDefinition {
   /**
    * Create a new {@link TargetMethodParameterDefinition}.
    *
-   * @param name              of the parameter.
-   * @param index             of the parameter in the method definition.
+   * @param name of the parameter.
+   * @param type of the parameter.
+   * @param index of the parameter in the method definition.
    * @param expanderClassName of the expander to use when resolving this parameter.
    */
-  private TargetMethodParameterDefinition(String name, Integer index, String expanderClassName) {
+  private TargetMethodParameterDefinition(String name, String type, Integer index,
+      String expanderClassName) {
     Assert.isNotEmpty(name, "name is required.");
+    Assert.isNotEmpty(type, "type is required.");
     Assert.isNotNull(index, "argument index is required.");
     Assert.isTrue(index, idx -> idx >= 0, "argument index must be a positive number");
+    Assert.isNotEmpty(expanderClassName, "expander class name is required.");
     this.name = name;
+    this.type = type;
     this.index = index;
     this.expanderClassName = expanderClassName;
   }
@@ -61,6 +66,15 @@ public class TargetMethodParameterDefinition {
    */
   public String getName() {
     return name;
+  }
+
+  /**
+   * Fully Qualified Class Name for the parameter type.
+   *
+   * @return parameter type.
+   */
+  public String getType() {
+    return this.type;
   }
 
   /**
@@ -91,12 +105,14 @@ public class TargetMethodParameterDefinition {
       return false;
     }
     TargetMethodParameterDefinition that = (TargetMethodParameterDefinition) obj;
-    return Objects.equals(name.toLowerCase(Locale.ROOT), that.name.toLowerCase(Locale.ROOT));
+    return getName().equalsIgnoreCase(that.getName()) && getType().equals(that.getType())
+        && getIndex().equals(that.getIndex())
+        && getExpanderClassName().equals(that.getExpanderClassName());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(getName(), getType(), getIndex(), getExpanderClassName());
   }
 
   @Override
@@ -104,6 +120,7 @@ public class TargetMethodParameterDefinition {
     return new StringJoiner(", ",
         TargetMethodParameterDefinition.class.getSimpleName() + "[", "]")
         .add("name='" + name + "'")
+        .add("type='" + type + "'")
         .add("index=" + index)
         .add("expanderClassName='" + expanderClassName + "'")
         .toString();
@@ -115,6 +132,7 @@ public class TargetMethodParameterDefinition {
   public static class Builder {
 
     private String name;
+    private String type;
     private Integer index;
     private String expanderClassName;
 
@@ -141,6 +159,17 @@ public class TargetMethodParameterDefinition {
     }
 
     /**
+     * Fully Qualified Class name of the parameter type.
+     *
+     * @param type of the parameter.
+     * @return a builder instance for chaining.
+     */
+    public Builder type(String type) {
+      this.type = type;
+      return this;
+    }
+
+    /**
      * Expression Expander Fully Qualified Class name to use when resolving this parameter value.
      *
      * @param expanderClassName of the {@link feign.template.ExpressionExpander}
@@ -157,7 +186,8 @@ public class TargetMethodParameterDefinition {
      * @return a new {@link TargetMethodParameterDefinition} instance.
      */
     public TargetMethodParameterDefinition build() {
-      return new TargetMethodParameterDefinition(this.name, this.index, this.expanderClassName);
+      return new TargetMethodParameterDefinition(this.name, this.type, this.index,
+          this.expanderClassName);
     }
   }
 }

--- a/core/src/main/java/feign/contract/AbstractAnnotationDrivenContract.java
+++ b/core/src/main/java/feign/contract/AbstractAnnotationDrivenContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 OpenFeign Contributors
+ * Copyright 2019-2021 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ public abstract class AbstractAnnotationDrivenContract implements Contract {
 
       /* determine if implicit body parameter identification is required */
       if (methodMetadata.getBody() == -1
-          && parameters.length > methodMetadata.getTemplateParameters().size()) {
+          && parameters.length > methodMetadata.getParameterDefinitions().size()) {
         /* there are parameters on this method that are not registered.  in these cases, we
          * allow users to define which parameter they want as the Request Body without an explicit
          * annotation, look for that parameter and register it.
@@ -136,6 +136,5 @@ public abstract class AbstractAnnotationDrivenContract implements Contract {
    */
   protected abstract void processAnnotationsOnParameter(Parameter parameter, Integer parameterIndex,
       TargetMethodDefinition.Builder targetMethodDefinitionBuilder);
-
 
 }

--- a/core/src/main/java/feign/impl/AbstractTargetMethodHandler.java
+++ b/core/src/main/java/feign/impl/AbstractTargetMethodHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 OpenFeign Contributors
+ * Copyright 2019-2021 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,17 +28,24 @@ import feign.ResponseDecoder;
 import feign.Retry;
 import feign.TargetMethodDefinition;
 import feign.TargetMethodHandler;
+import feign.TargetMethodParameterDefinition;
 import feign.exception.FeignException;
 import feign.http.RequestSpecification;
 import feign.impl.type.TypeDefinition;
 import feign.support.Assert;
+import feign.template.ExpanderRegistry;
+import feign.template.ExpressionExpander;
+import feign.template.SimpleTemplateParameter;
 import feign.template.TemplateParameter;
+import feign.template.expander.CachingExpanderRegistry;
+import feign.template.expander.DefaultExpander;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import org.slf4j.LoggerFactory;
 
@@ -61,6 +68,8 @@ public abstract class AbstractTargetMethodHandler implements TargetMethodHandler
   private final Logger logger;
   private final Executor executor;
   private final Retry retry;
+  private final Map<Integer, TemplateParameter> parameterMap = new ConcurrentHashMap<>();
+  private ExpanderRegistry expanderRegistry = new CachingExpanderRegistry();
 
   /**
    * Creates a new Abstract Target HttpMethod Handler.
@@ -293,16 +302,55 @@ public abstract class AbstractTargetMethodHandler implements TargetMethodHandler
    *
    * @param arguments to map.
    * @return a new Map, where the argument matches corresponding Template parameter.
+   * @throws IllegalStateException if the arguments could not be mapped.
    */
   private Map<TemplateParameter, Object> mapArguments(Object[] arguments) {
     Map<TemplateParameter, Object> variables = new LinkedHashMap<>();
     for (int i = 0; i < arguments.length; i++) {
+      final int index = i;
       final Object argument = arguments[i];
-      Optional<TemplateParameter> templateParameter =
-          this.targetMethodDefinition.getTemplateParameter(i);
-      templateParameter.ifPresent(parameter -> variables.put(parameter, argument));
+      Optional<TargetMethodParameterDefinition> parameterDefinition =
+          this.targetMethodDefinition.getParameterDefinition(i);
+      parameterDefinition.ifPresent(parameter -> variables.put(
+          getTemplateParameterForIndex(index, parameter), argument));
     }
     return variables;
+  }
+
+  /**
+   * Retrieve the {@link TemplateParameter} for the specified method parameter index.
+   *
+   * @param index of the parameter.
+   * @param definition of the parameter.
+   * @return the {@link TemplateParameter} instance at this index.
+   * @throws IllegalStateException if the {@link TemplateParameter} instance could not be retrieved.
+   */
+  private TemplateParameter getTemplateParameterForIndex(int index,
+      TargetMethodParameterDefinition definition) {
+    return this.parameterMap.computeIfAbsent(index,
+        idx -> new SimpleTemplateParameter(definition.getName(),
+            getExpressionExpanderFor(definition)));
+  }
+
+  /**
+   * Obtain the {@link ExpressionExpander} instance for definition.
+   *
+   * @param parameterDefinition to evaluate.
+   * @return the {@link ExpressionExpander} instance for the parameter.
+   * @throws IllegalStateException if the {@link ExpressionExpander} instance could not be obtained.
+   */
+  @SuppressWarnings("unchecked")
+  private ExpressionExpander getExpressionExpanderFor(
+      TargetMethodParameterDefinition parameterDefinition) {
+    String expanderClassName = parameterDefinition.getExpanderClassName();
+    try {
+      Class<? extends ExpressionExpander> expanderClass =
+          (Class<? extends ExpressionExpander>) Class.forName(expanderClassName);
+      return this.expanderRegistry.getExpander(expanderClass, parameterDefinition.getType());
+    } catch (Exception ex) {
+      throw new IllegalStateException(
+          "Expression Expander instance " + expanderClassName + " not found.", ex);
+    }
   }
 
   /**
@@ -323,4 +371,13 @@ public abstract class AbstractTargetMethodHandler implements TargetMethodHandler
     this.logger.logResponse(method, response);
   }
 
+
+  /**
+   * Override the Expander Registry.
+   *
+   * @param expanderRegistry to use.
+   */
+  void setExpanderRegistry(ExpanderRegistry expanderRegistry) {
+    this.expanderRegistry = expanderRegistry;
+  }
 }

--- a/core/src/main/java/feign/impl/AbstractTargetMethodHandler.java
+++ b/core/src/main/java/feign/impl/AbstractTargetMethodHandler.java
@@ -38,7 +38,6 @@ import feign.template.ExpressionExpander;
 import feign.template.SimpleTemplateParameter;
 import feign.template.TemplateParameter;
 import feign.template.expander.CachingExpanderRegistry;
-import feign.template.expander.DefaultExpander;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/core/src/main/java/feign/template/ExpanderRegistry.java
+++ b/core/src/main/java/feign/template/ExpanderRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 OpenFeign Contributors
+ * Copyright 2019-2021 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,5 +37,6 @@ public interface ExpanderRegistry {
    * @return an {@link ExpressionExpander} instance of the type provided.
    * @throws IllegalStateException if the expander instance could be created.
    */
-  ExpressionExpander getExpander(Class<? extends ExpressionExpander> expanderClass);
+  ExpressionExpander getExpander(Class<? extends ExpressionExpander> expanderClass,
+      String typeClassName);
 }

--- a/core/src/test/java/feign/TargetMethodParameterDefinitionTest.java
+++ b/core/src/test/java/feign/TargetMethodParameterDefinitionTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
+import feign.template.expander.DefaultExpander;
 import org.junit.jupiter.api.Test;
 
 class TargetMethodParameterDefinitionTest {
@@ -30,22 +31,13 @@ class TargetMethodParameterDefinitionTest {
     TargetMethodParameterDefinition parameterDefinition = TargetMethodParameterDefinition.builder()
         .name("parameter")
         .index(0)
+        .type(String.class.getName())
         .expanderClassName("io.openfeign.expander.StringExpander")
         .build();
     assertThat(parameterDefinition.getName()).isNotEmpty();
     assertThat(parameterDefinition.getIndex()).isNotNull().isEqualTo(0);
     assertThat(parameterDefinition.getExpanderClassName()).isNotEmpty();
-  }
-
-  @Test
-  void expander_isOptional() {
-    TargetMethodParameterDefinition parameterDefinition = TargetMethodParameterDefinition.builder()
-        .name("parameter")
-        .index(0)
-        .build();
-    assertThat(parameterDefinition.getName()).isNotEmpty();
-    assertThat(parameterDefinition.getIndex()).isNotNull().isEqualTo(0);
-    assertThat(parameterDefinition.getExpanderClassName()).isNull();
+    assertThat(parameterDefinition.getType()).isNotEmpty();
   }
 
   @Test
@@ -59,6 +51,8 @@ class TargetMethodParameterDefinitionTest {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> TargetMethodParameterDefinition.builder()
             .name("name")
+            .expanderClassName(DefaultExpander.class.getName())
+            .type(String.class.getName())
             .build());
   }
 
@@ -68,6 +62,28 @@ class TargetMethodParameterDefinitionTest {
         .isThrownBy(() -> TargetMethodParameterDefinition.builder()
             .name("name")
             .index(-1)
+            .expanderClassName(DefaultExpander.class.getName())
+            .type(String.class.getName())
+            .build());
+  }
+
+  @Test
+  void type_isRequired() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> TargetMethodParameterDefinition.builder()
+        .name("name")
+        .index(0)
+        .expanderClassName(DefaultExpander.class.getName())
+        .build());
+  }
+
+  @Test
+  void expanderClass_isRequired() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> TargetMethodParameterDefinition.builder()
+            .name("name")
+            .index(0)
+            .type(String.class.getName())
             .build());
   }
 
@@ -76,10 +92,14 @@ class TargetMethodParameterDefinitionTest {
     assertThat(TargetMethodParameterDefinition.builder()
         .name("param")
         .index(0)
+        .type(String.class.getName())
+        .expanderClassName(DefaultExpander.class.getName())
         .build()).isEqualTo(
         TargetMethodParameterDefinition.builder()
             .name("PARAM")
             .index(0)
+            .type(String.class.getName())
+            .expanderClassName(DefaultExpander.class.getName())
             .build());
   }
 
@@ -88,6 +108,8 @@ class TargetMethodParameterDefinitionTest {
     TargetMethodParameterDefinition parameterDefinition = TargetMethodParameterDefinition.builder()
         .name("param")
         .index(0)
+        .type(String.class.getName())
+        .expanderClassName(DefaultExpander.class.getName())
         .build();
     assertThat(parameterDefinition).isEqualTo(parameterDefinition);
   }
@@ -97,10 +119,14 @@ class TargetMethodParameterDefinitionTest {
     assertThat(TargetMethodParameterDefinition.builder()
         .name("param")
         .index(0)
+        .type(String.class.getName())
+        .expanderClassName(DefaultExpander.class.getName())
         .build()).isNotEqualTo(
         TargetMethodParameterDefinition.builder()
-            .name("name")
+            .name("another")
             .index(0)
+            .type(String.class.getName())
+            .expanderClassName(DefaultExpander.class.getName())
             .build());
   }
 
@@ -109,6 +135,8 @@ class TargetMethodParameterDefinitionTest {
     assertThat(TargetMethodParameterDefinition.builder()
         .name("param")
         .index(0)
+        .type(String.class.getName())
+        .expanderClassName(DefaultExpander.class.getName())
         .build()).isNotEqualTo("A String");
   }
 
@@ -117,7 +145,8 @@ class TargetMethodParameterDefinitionTest {
     assertThat(TargetMethodParameterDefinition.builder()
         .name("param")
         .index(0)
-        .build()
+        .type(String.class.getName())
+        .expanderClassName(DefaultExpander.class.getName())
         .toString()).isNotEmpty();
   }
 }

--- a/core/src/test/java/feign/TargetMethodParameterDefinitionTest.java
+++ b/core/src/test/java/feign/TargetMethodParameterDefinitionTest.java
@@ -21,7 +21,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
+import feign.template.ExpressionExpander;
 import feign.template.expander.DefaultExpander;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class TargetMethodParameterDefinitionTest {
@@ -131,6 +133,54 @@ class TargetMethodParameterDefinitionTest {
   }
 
   @Test
+  void notEquals_index() {
+    assertThat(TargetMethodParameterDefinition.builder()
+        .name("param")
+        .index(0)
+        .type(String.class.getName())
+        .expanderClassName(DefaultExpander.class.getName())
+        .build()).isNotEqualTo(
+        TargetMethodParameterDefinition.builder()
+            .name("param")
+            .index(1)
+            .type(String.class.getName())
+            .expanderClassName(DefaultExpander.class.getName())
+            .build());
+  }
+
+  @Test
+  void notEquals_type() {
+    assertThat(TargetMethodParameterDefinition.builder()
+        .name("param")
+        .index(0)
+        .type(String.class.getName())
+        .expanderClassName(DefaultExpander.class.getName())
+        .build()).isNotEqualTo(
+        TargetMethodParameterDefinition.builder()
+            .name("param")
+            .index(0)
+            .type(List.class.getName())
+            .expanderClassName(DefaultExpander.class.getName())
+            .build());
+  }
+
+  @Test
+  void notEquals_expander() {
+    assertThat(TargetMethodParameterDefinition.builder()
+        .name("param")
+        .index(0)
+        .type(String.class.getName())
+        .expanderClassName(DefaultExpander.class.getName())
+        .build()).isNotEqualTo(
+        TargetMethodParameterDefinition.builder()
+            .name("param")
+            .index(0)
+            .type(List.class.getName())
+            .expanderClassName(ExpressionExpander.class.getName())
+            .build());
+  }
+
+  @Test
   void notEqual_toOtherTypes() {
     assertThat(TargetMethodParameterDefinition.builder()
         .name("param")
@@ -147,6 +197,18 @@ class TargetMethodParameterDefinitionTest {
         .index(0)
         .type(String.class.getName())
         .expanderClassName(DefaultExpander.class.getName())
+        .build()
         .toString()).isNotEmpty();
+  }
+
+  @Test
+  void hashCode_isNotEmpty() {
+    assertThat(TargetMethodParameterDefinition.builder()
+        .name("param")
+        .index(0)
+        .type(String.class.getName())
+        .expanderClassName(DefaultExpander.class.getName())
+        .build()
+        .hashCode()).isNotNull();
   }
 }

--- a/core/src/test/java/feign/contract/FeignContractTest.java
+++ b/core/src/test/java/feign/contract/FeignContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 OpenFeign Contributors
+ * Copyright 2019-2021 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,11 @@ import feign.Contract;
 import feign.RequestOptions;
 import feign.Response;
 import feign.TargetMethodDefinition;
+import feign.TargetMethodParameterDefinition;
 import feign.http.HttpMethod;
 import feign.impl.UriTarget;
 import feign.template.SimpleTemplateParameter;
+import feign.template.expander.DefaultExpander;
 import feign.template.expander.ListExpander;
 import feign.template.expander.MapExpander;
 import java.util.Collection;
@@ -54,7 +56,7 @@ class FeignContractTest {
         targetMethodDefinition -> targetMethodDefinition.getName().equalsIgnoreCase("get")
             && targetMethodDefinition.getReturnType().getType() == String.class
             && targetMethodDefinition.getMethod() == HttpMethod.GET
-            && targetMethodDefinition.getTemplateParameters().isEmpty()
+            && targetMethodDefinition.getParameterDefinitions().isEmpty()
             && targetMethodDefinition.getBody() == -1
             && targetMethodDefinition.getConnectTimeout() == RequestOptions.DEFAULT_CONNECT_TIMEOUT
             && targetMethodDefinition.getReadTimeout() == RequestOptions.DEFAULT_READ_TIMEOUT
@@ -65,8 +67,13 @@ class FeignContractTest {
         targetMethodDefinition -> targetMethodDefinition.getName().equalsIgnoreCase("post")
             && targetMethodDefinition.getReturnType().getType() == String.class
             && targetMethodDefinition.getMethod() == HttpMethod.POST
-            && targetMethodDefinition.getTemplateParameters().contains(
-            new SimpleTemplateParameter("parameter"))
+            && targetMethodDefinition.getParameterDefinitions().contains(
+            TargetMethodParameterDefinition.builder()
+                .name("parameter")
+                .index(0)
+                .type(String.class.getCanonicalName())
+                .expanderClassName(DefaultExpander.class.getName())
+                .build())
             && targetMethodDefinition.getBody() == 1);
 
     /* explicit body parameter */
@@ -74,8 +81,13 @@ class FeignContractTest {
         targetMethodDefinition -> targetMethodDefinition.getName().equalsIgnoreCase("put")
             && targetMethodDefinition.getReturnType().getType() == String.class
             && targetMethodDefinition.getMethod() == HttpMethod.PUT
-            && targetMethodDefinition.getTemplateParameters()
-            .contains(new SimpleTemplateParameter("parameter"))
+            && targetMethodDefinition.getParameterDefinitions()
+            .contains(TargetMethodParameterDefinition.builder()
+                .name("parameter")
+                .index(0)
+                .type(String.class.getCanonicalName())
+                .expanderClassName(DefaultExpander.class.getName())
+                .build())
             && targetMethodDefinition.getBody() == 1);
 
     /* void return type */
@@ -83,8 +95,13 @@ class FeignContractTest {
         targetMethodDefinition -> targetMethodDefinition.getName().equalsIgnoreCase("delete")
             && targetMethodDefinition.getReturnType().getType() == void.class
             && targetMethodDefinition.getMethod() == HttpMethod.DELETE
-            && targetMethodDefinition.getTemplateParameters()
-            .contains(new SimpleTemplateParameter("parameter"))
+            && targetMethodDefinition.getParameterDefinitions()
+            .contains(TargetMethodParameterDefinition.builder()
+                .name("parameter")
+                .index(0)
+                .type(String.class.getCanonicalName())
+                .expanderClassName(DefaultExpander.class.getName())
+                .build())
             && targetMethodDefinition.getBody() == -1);
 
     /* request options and generic return type */
@@ -92,7 +109,7 @@ class FeignContractTest {
         targetMethodDefinition -> targetMethodDefinition.getName().equalsIgnoreCase("search")
             && targetMethodDefinition.getReturnType().getType() == List.class
             && targetMethodDefinition.getMethod() == HttpMethod.GET
-            && targetMethodDefinition.getTemplateParameters().isEmpty()
+            && targetMethodDefinition.getParameterDefinitions().isEmpty()
             && targetMethodDefinition.getBody() == -1
             && targetMethodDefinition.getConnectTimeout() == 1000
             && targetMethodDefinition.getReadTimeout() == 2000
@@ -106,9 +123,10 @@ class FeignContractTest {
           && targetMethodDefinition.getBody() == -1;
       assertThat(properties).isTrue();
 
-      targetMethodDefinition.getTemplateParameter(0)
+      targetMethodDefinition.getParameterDefinition(0)
           .ifPresent(
-              parameter -> assertThat(parameter.expander()).isInstanceOf(MapExpander.class));
+              parameter -> assertThat(parameter.getType())
+                  .isEqualToIgnoringCase(Map.class.getCanonicalName()));
     });
 
     /* list parameter type */
@@ -120,9 +138,10 @@ class FeignContractTest {
               && targetMethodDefinition.getBody() == -1;
           assertThat(properties).isTrue();
 
-          targetMethodDefinition.getTemplateParameter(0)
+          targetMethodDefinition.getParameterDefinition(0)
               .ifPresent(
-                  parameter -> assertThat(parameter.expander()).isInstanceOf(ListExpander.class));
+                  parameter -> assertThat(parameter.getType())
+                      .isEqualToIgnoringCase(List.class.getCanonicalName()));
         });
 
     /* response return type */
@@ -130,8 +149,13 @@ class FeignContractTest {
         targetMethodDefinition -> targetMethodDefinition.getName().equalsIgnoreCase("response")
             && targetMethodDefinition.getReturnType().getType() == Response.class
             && targetMethodDefinition.getMethod() == HttpMethod.GET
-            && targetMethodDefinition.getTemplateParameters()
-            .contains(new SimpleTemplateParameter("parameters"))
+            && targetMethodDefinition.getParameterDefinitions()
+            .contains(TargetMethodParameterDefinition.builder()
+                .name("parameters")
+                .index(0)
+                .type(String.class.getCanonicalName())
+                .expanderClassName(DefaultExpander.class.getName())
+                .build())
             && targetMethodDefinition.getBody() == -1);
   }
 

--- a/core/src/test/java/feign/impl/AbstractTargetMethodHandlerTest.java
+++ b/core/src/test/java/feign/impl/AbstractTargetMethodHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 OpenFeign Contributors
+ * Copyright 2019-2021 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package feign.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -40,10 +41,14 @@ import feign.ResponseDecoder;
 import feign.Retry;
 import feign.TargetMethodDefinition;
 import feign.TargetMethodHandler;
+import feign.TargetMethodParameterDefinition;
 import feign.http.HttpMethod;
 import feign.http.RequestSpecification;
 import feign.retry.NoRetry;
-import feign.template.SimpleTemplateParameter;
+import feign.template.ExpanderRegistry;
+import feign.template.ExpressionExpander;
+import feign.template.expander.CachingExpanderRegistry;
+import feign.template.expander.DefaultExpander;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.Collections;
@@ -92,7 +97,6 @@ class AbstractTargetMethodHandlerTest {
   void setUp() {
     this.targetMethodDefinition = TargetMethodDefinition.builder(
         new UriTarget<>(TestInterface.class, "https://www.example.com"));
-
   }
 
   @Test
@@ -102,7 +106,12 @@ class AbstractTargetMethodHandlerTest {
     this.targetMethodDefinition.returnType(String.class)
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
-        .templateParameter(0, new SimpleTemplateParameter("name"))
+        .parameterDefinition(0, TargetMethodParameterDefinition.builder()
+            .name("name")
+            .type(String.class.getName())
+            .index(0)
+            .expanderClassName(DefaultExpander.class.getName())
+            .build())
         .body(1);
     TargetMethodDefinition methodDefinition = this.targetMethodDefinition.build();
     TargetMethodHandler targetMethodHandler = new BlockingTargetMethodHandler(
@@ -130,7 +139,12 @@ class AbstractTargetMethodHandlerTest {
     this.targetMethodDefinition.returnType(String.class)
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
-        .templateParameter(0, new SimpleTemplateParameter("name"))
+        .parameterDefinition(0, TargetMethodParameterDefinition.builder()
+            .name("name")
+            .type(String.class.getName())
+            .index(0)
+            .expanderClassName(DefaultExpander.class.getName())
+            .build())
         .body(1);
 
     TargetMethodDefinition methodDefinition = this.targetMethodDefinition.build();
@@ -182,7 +196,12 @@ class AbstractTargetMethodHandlerTest {
     this.targetMethodDefinition.returnType(String.class)
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
-        .templateParameter(0, new SimpleTemplateParameter("name"))
+        .parameterDefinition(0, TargetMethodParameterDefinition.builder()
+            .name("name")
+            .type(String.class.getName())
+            .index(0)
+            .expanderClassName(DefaultExpander.class.getName())
+            .build())
         .body(1);
 
     TargetMethodDefinition methodDefinition = this.targetMethodDefinition.build();
@@ -209,9 +228,14 @@ class AbstractTargetMethodHandlerTest {
     when(this.client.request(any(Request.class))).thenReturn(this.response);
     when(this.response.body()).thenReturn(mock(InputStream.class));
     this.targetMethodDefinition.returnType(String.class)
-            .uri("/resources/{name}")
-            .method(HttpMethod.GET)
-            .templateParameter(0, new SimpleTemplateParameter("name"));
+        .uri("/resources/{name}")
+        .method(HttpMethod.GET)
+        .parameterDefinition(0, TargetMethodParameterDefinition.builder()
+            .name("name")
+            .type(String.class.getName())
+            .index(0)
+            .expanderClassName(DefaultExpander.class.getName())
+            .build());
 
     TargetMethodDefinition methodDefinition = this.targetMethodDefinition.build();
     TargetMethodHandler targetMethodHandler = new BlockingTargetMethodHandler(
@@ -238,7 +262,12 @@ class AbstractTargetMethodHandlerTest {
     this.targetMethodDefinition.returnType(Response.class)
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
-        .templateParameter(0, new SimpleTemplateParameter("name"));
+        .parameterDefinition(0, TargetMethodParameterDefinition.builder()
+            .name("name")
+            .type(String.class.getName())
+            .index(0)
+            .expanderClassName(DefaultExpander.class.getName())
+            .build());
 
     TargetMethodDefinition methodDefinition = this.targetMethodDefinition.build();
     TargetMethodHandler targetMethodHandler = new BlockingTargetMethodHandler(
@@ -263,7 +292,12 @@ class AbstractTargetMethodHandlerTest {
     this.targetMethodDefinition.returnType(Response.class)
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
-        .templateParameter(0, new SimpleTemplateParameter("name"));
+        .parameterDefinition(0, TargetMethodParameterDefinition.builder()
+            .name("name")
+            .type(String.class.getName())
+            .index(0)
+            .expanderClassName(DefaultExpander.class.getName())
+            .build());
 
     TargetMethodDefinition methodDefinition = this.targetMethodDefinition.build();
     TargetMethodHandler targetMethodHandler = new BlockingTargetMethodHandler(
@@ -289,7 +323,12 @@ class AbstractTargetMethodHandlerTest {
     this.targetMethodDefinition.returnType(Response.class)
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
-        .templateParameter(0, new SimpleTemplateParameter("name"));
+        .parameterDefinition(0, TargetMethodParameterDefinition.builder()
+            .name("name")
+            .type(String.class.getName())
+            .index(0)
+            .expanderClassName(DefaultExpander.class.getName())
+            .build());
 
     TargetMethodDefinition methodDefinition = this.targetMethodDefinition.build();
     TargetMethodHandler targetMethodHandler = new BlockingTargetMethodHandler(
@@ -315,7 +354,12 @@ class AbstractTargetMethodHandlerTest {
     this.targetMethodDefinition.returnType(void.class)
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
-        .templateParameter(0, new SimpleTemplateParameter("name"));
+        .parameterDefinition(0, TargetMethodParameterDefinition.builder()
+            .name("name")
+            .type(String.class.getName())
+            .index(0)
+            .expanderClassName(DefaultExpander.class.getName())
+            .build());
 
     TargetMethodDefinition methodDefinition = this.targetMethodDefinition.build();
     TargetMethodHandler targetMethodHandler = new BlockingTargetMethodHandler(
@@ -343,7 +387,12 @@ class AbstractTargetMethodHandlerTest {
     this.targetMethodDefinition.returnType(Response.class)
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
-        .templateParameter(0, new SimpleTemplateParameter("name"))
+        .parameterDefinition(0, TargetMethodParameterDefinition.builder()
+            .name("name")
+            .type(String.class.getName())
+            .index(0)
+            .expanderClassName(DefaultExpander.class.getName())
+            .build())
         .readTimeout(1000)
         .body(1);
 
@@ -371,7 +420,12 @@ class AbstractTargetMethodHandlerTest {
     this.targetMethodDefinition.returnType(Response.class)
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
-        .templateParameter(0, new SimpleTemplateParameter("name"));
+        .parameterDefinition(0, TargetMethodParameterDefinition.builder()
+            .name("name")
+            .type(String.class.getCanonicalName())
+            .index(0)
+            .expanderClassName(DefaultExpander.class.getName())
+            .build());
 
     TargetMethodDefinition methodDefinition = this.targetMethodDefinition.build();
     TargetMethodHandler targetMethodHandler = new BlockingTargetMethodHandler(
@@ -400,7 +454,12 @@ class AbstractTargetMethodHandlerTest {
     this.targetMethodDefinition.returnType(String.class)
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
-        .templateParameter(0, new SimpleTemplateParameter("name"))
+        .parameterDefinition(0, TargetMethodParameterDefinition.builder()
+            .name("name")
+            .type(String.class.getCanonicalName())
+            .index(0)
+            .expanderClassName(DefaultExpander.class.getName())
+            .build())
         .body(1);
 
     ExceptionHandler exceptionHandler = spy(new RethrowExceptionHandler());
@@ -422,6 +481,42 @@ class AbstractTargetMethodHandlerTest {
     verify(client, times(1)).request(any(Request.class));
     verify(decoder, times(1)).decode(any(Response.class), eq(String.class));
     verify(exceptionHandler, times(1)).apply(any(Throwable.class));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void ensureTemplateParameters_areCached() {
+    this.targetMethodDefinition.returnType(String.class)
+        .uri("/resources/{name}")
+        .method(HttpMethod.GET)
+        .parameterDefinition(0, TargetMethodParameterDefinition.builder()
+            .name("name")
+            .type(String.class.getCanonicalName())
+            .index(0)
+            .expanderClassName(DefaultExpander.class.getName())
+            .build())
+        .body(1);
+
+    ExpanderRegistry expanderRegistry = spy(new CachingExpanderRegistry());
+    BlockingTargetMethodHandler targetMethodHandler = new BlockingTargetMethodHandler(
+        this.targetMethodDefinition.build(),
+        this.encoder,
+        Collections.singletonList(this.interceptor),
+        this.client,
+        this.decoder,
+        exceptionHandler,
+        this.executor,
+        this.logger,
+        this.retry);
+    targetMethodHandler.setExpanderRegistry(expanderRegistry);
+
+    /* call the method twice, expect the expander registry to be invoked only once */
+    targetMethodHandler.execute(Arrays.array("name", "body"));
+    targetMethodHandler.execute(Arrays.array("name", "body"));
+
+    verify(expanderRegistry, times(1))
+        .getExpander(any(Class.class), anyString());
+
   }
 
   interface TestInterface {

--- a/core/src/test/java/feign/template/expander/CachingExpanderRegistryTest.java
+++ b/core/src/test/java/feign/template/expander/CachingExpanderRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 OpenFeign Contributors
+ * Copyright 2019-2021 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,20 +64,31 @@ class CachingExpanderRegistryTest {
 
   @Test
   void customExpanderTypes_shouldBeInstantiated() {
-    ExpressionExpander expander = this.expanderRegistry.getExpander(CustomExpander.class);
+    ExpressionExpander expander = this.expanderRegistry
+        .getExpander(CustomExpander.class, String.class.getCanonicalName());
     assertThat(expander).isNotNull().isInstanceOf(CustomExpander.class);
   }
 
   @Test
   void customExpanderTypes_shouldBeReused() {
-    ExpressionExpander expander = this.expanderRegistry.getExpander(CustomExpander.class);
-    assertThat(expander).isEqualTo(this.expanderRegistry.getExpander(CustomExpander.class));
+    ExpressionExpander expander = this.expanderRegistry
+        .getExpander(CustomExpander.class, String.class.getCanonicalName());
+    assertThat(expander).isEqualTo(
+        this.expanderRegistry.getExpander(CustomExpander.class, String.class.getCanonicalName()));
   }
 
   @Test
   void customExpanderTypes_mustHaveDefaultConstructor() {
     assertThrows(IllegalStateException.class,
-        () -> this.expanderRegistry.getExpander(InvalidExpander.class));
+        () -> this.expanderRegistry
+            .getExpander(InvalidExpander.class, String.class.getCanonicalName()));
+  }
+
+  @Test
+  void defaultExpander_usesParameterType() {
+    ExpressionExpander expander =
+      this.expanderRegistry.getExpander(DefaultExpander.class, String.class.getCanonicalName());
+    assertThat(expander).isInstanceOf(SimpleExpander.class);
   }
 
   static class CustomExpander implements ExpressionExpander {


### PR DESCRIPTION
Related to #57

This change moves `TemplateParameter` object creation to `AbstractTargetMethodHandler` to reduce the overhead of `Contract` parsing and reduce the responsibility of `Contract` implementations to class metadata and not collaborating object construction.