### PR TITLE
[GH-57] Introduce Annotation Processors

### DIFF
--- a/core/src/main/java/feign/contract/AnnotationProcessor.java
+++ b/core/src/main/java/feign/contract/AnnotationProcessor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019-2021 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.contract;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * Annotation Processor interface.  Used by Annotation Driven Contracts to process annotated methods
+ * and classes.  These processors are designed to be used in both reflective and compile-time modes.
+ *
+ * @param <T> Supported annotation type.
+ */
+public interface AnnotationProcessor<T extends Annotation> {
+
+  /**
+   * Evaluate and process the provided annotation, updating the provided builder.  Implementations
+   * are expected to update builder via side-effects.
+   *
+   * @param annotation to evaluate.
+   * @param builder    with the current method context.
+   */
+  void process(T annotation, TargetMethodDefinition.Builder builder);
+
+}

--- a/core/src/main/java/feign/contract/FeignContract.java
+++ b/core/src/main/java/feign/contract/FeignContract.java
@@ -16,17 +16,13 @@
 
 package feign.contract;
 
-import feign.http.HttpHeader;
-import feign.http.HttpMethod;
-import feign.impl.type.TypeDefinition;
-import feign.support.StringUtils;
-import feign.template.ExpressionExpander;
-import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
-import java.lang.reflect.Type;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
+import feign.contract.impl.BodyAnnotationProcessor;
+import feign.contract.impl.HeadersAnnotationProcessor;
+import feign.contract.impl.ParamAnnotationProcessor;
+import feign.contract.impl.RequestAnnotationProcessor;
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.Set;
 
 /**
  * Contract that uses Feign annotations.
@@ -38,173 +34,39 @@ public class FeignContract extends AbstractAnnotationDrivenContract {
    */
   public FeignContract() {
     super();
+    this.registerAnnotationProcessor(Request.class, new RequestAnnotationProcessor());
+    this.registerAnnotationProcessor(Headers.class, new HeadersAnnotationProcessor());
+    this.registerParameterAnnotationProcessor(Param.class, new ParamAnnotationProcessor());
+    this.registerParameterAnnotationProcessor(Body.class, new BodyAnnotationProcessor());
   }
 
   /**
-   * Process any Annotations present on the Target Type.  Any values determined here should be
-   * considered common for all methods in the Target.
+   * Support {@link Request} and {@link Headers} at the class level.
    *
-   * @param targetType             to inspect.
-   * @param targetMethodDefinition to store the resulting configuration.
+   * @return set of supported annotations at the class level.
    */
   @Override
-  protected void processAnnotationsOnType(Class<?> targetType,
-      TargetMethodDefinition.Builder targetMethodDefinition) {
-    if (targetType.isAnnotationPresent(Request.class)) {
-      this.processRequest(targetType.getAnnotation(Request.class), targetMethodDefinition);
-    }
-    if (targetType.isAnnotationPresent(Headers.class)) {
-      this.processHeaders(targetType.getAnnotation(Headers.class), targetMethodDefinition);
-    }
+  protected Collection<Class<? extends Annotation>> getSupportedClassAnnotations() {
+    return Set.of(Request.class, Headers.class);
   }
 
   /**
-   * Process any Annotations present on the Method.
+   * Support the same items at the class level at the method level.
    *
-   * @param targetType             containing the method.
-   * @param method                 to inspect.
-   * @param targetMethodDefinition to store the resulting configuration.
+   * @return a set of supported annotations at the method level.
    */
   @Override
-  protected void processAnnotationsOnMethod(Class<?> targetType, Method method,
-      TargetMethodDefinition.Builder targetMethodDefinition) {
-    if (method.isAnnotationPresent(Request.class)) {
-      targetMethodDefinition
-          .name(method.getName())
-          .tag(this.getMethodTag(targetType, method))
-          .returnType(this.getMethodReturnType(method));
-      this.processRequest(method.getAnnotation(Request.class), targetMethodDefinition);
-    }
-    if (method.isAnnotationPresent(Headers.class)) {
-      this.processHeaders(method.getAnnotation(Headers.class), targetMethodDefinition);
-    }
+  protected Collection<Class<? extends Annotation>> getSupportedMethodAnnotations() {
+    return this.getSupportedClassAnnotations();
   }
 
   /**
-   * Process any Annotations present on the method Parameter.
+   * Support the {@link Param} and {@link Body} annotations at the parameter level.
    *
-   * @param parameter              to inspect.
-   * @param parameterIndex         of the parameter in the method signature.
-   * @param targetMethodDefinition to store the resulting configuration.
+   * @return the set of supported annotations at the parameter level.
    */
   @Override
-  protected void processAnnotationsOnParameter(Parameter parameter, Integer parameterIndex,
-      TargetMethodDefinition.Builder targetMethodDefinition) {
-    if (parameter.isAnnotationPresent(Param.class)) {
-      this.processParameter(
-          parameter.getAnnotation(Param.class),
-          parameterIndex,
-          parameter.getType(),
-          targetMethodDefinition);
-    }
-    if (parameter.isAnnotationPresent(Body.class)) {
-      targetMethodDefinition.body(parameterIndex);
-    }
+  protected Collection<Class<? extends Annotation>> getSupportedParameterAnnotations() {
+    return Set.of(Param.class, Body.class);
   }
-
-  /**
-   * Process the HttpRequest annotation.
-   *
-   * @param request                annotation to process.
-   * @param targetMethodDefinition for the request.
-   */
-  private void processRequest(Request request,
-      TargetMethodDefinition.Builder targetMethodDefinition) {
-    String uri = (StringUtils.isNotEmpty(request.uri())) ? request.uri() : request.value();
-    HttpMethod httpMethod = request.method();
-    boolean followRedirects = request.followRedirects();
-
-    targetMethodDefinition.uri(uri)
-        .method(httpMethod)
-        .followRedirects(followRedirects)
-        .connectTimeout(request.connectTimeout())
-        .readTimeout(request.readTimeout());
-  }
-
-  /**
-   * Process the Headers annotation.
-   *
-   * @param headers                annotation to process.
-   * @param targetMethodDefinition for the request.
-   */
-  private void processHeaders(Headers headers,
-      TargetMethodDefinition.Builder targetMethodDefinition) {
-    if (headers.value().length != 0) {
-      Header[] header = headers.value();
-      for (Header value : header) {
-        this.processHeader(value, targetMethodDefinition);
-      }
-    }
-  }
-
-  /**
-   * Process the Header annotation.
-   *
-   * @param header                 annotation to process.
-   * @param targetMethodDefinition for the header.
-   */
-  private void processHeader(Header header, TargetMethodDefinition.Builder targetMethodDefinition) {
-    HttpHeader httpHeader = new HttpHeader(header.name());
-    httpHeader.value(header.value());
-    targetMethodDefinition.header(httpHeader);
-  }
-
-  /**
-   * Process the Param annotation.
-   *
-   * @param parameter              annotation to process.
-   * @param index                  of the parameter in the method signature.
-   * @param type                   of the parameter.
-   * @param targetMethodDefinition for the parameter.
-   */
-  private void processParameter(Param parameter, Integer index, Class<?> type,
-      TargetMethodDefinition.Builder targetMethodDefinition) {
-
-    String name = parameter.value();
-    String typeClass = type.getCanonicalName();
-
-    Class<? extends ExpressionExpander> expanderClass = parameter.expander();
-    String expanderClassName = expanderClass.getName();
-
-    targetMethodDefinition.parameterDefinition(
-        index, TargetMethodParameterDefinition.builder()
-            .name(name)
-            .index(index)
-            .type(typeClass)
-            .expanderClassName(expanderClassName)
-            .build());
-  }
-
-  /**
-   * Constructs a name for a Method that is formatted as a javadoc reference.
-   *
-   * @param targetType containing the method.
-   * @param method     to inspect.
-   * @return a See Tag inspired name for the method.
-   */
-  private String getMethodTag(Class<?> targetType, Method method) {
-    StringBuilder sb = new StringBuilder()
-        .append(targetType.getSimpleName())
-        .append("#")
-        .append(method.getName())
-        .append("(");
-    List<Type> parameters = Arrays.asList(method.getGenericParameterTypes());
-    Iterator<Type> iterator = parameters.iterator();
-    while (iterator.hasNext()) {
-      Type parameter = iterator.next();
-      sb.append(parameter.getTypeName());
-      if (iterator.hasNext()) {
-        sb.append(",");
-      }
-    }
-    sb.append(")");
-    return sb.toString();
-  }
-
-  private TypeDefinition getMethodReturnType(Method method) {
-    return this.typeDefinitionFactory
-        .create(method.getGenericReturnType(), method.getDeclaringClass());
-  }
-
-
 }

--- a/core/src/main/java/feign/contract/ParameterAnnotationProcessor.java
+++ b/core/src/main/java/feign/contract/ParameterAnnotationProcessor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019-2021 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.contract;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * Interface for Annotation Processors responsible for dealing with annotated method parameters.
+ * Used in both reflective and compile time modes.
+ *
+ * @param <T> supported annotation.
+ */
+public interface ParameterAnnotationProcessor<T extends Annotation> {
+
+  /**
+   * Evaluate the annotation against the provided parameter information.  Implementations are
+   * expected to update the builder via side-effects.
+   *
+   * @param annotation to evaluate.
+   * @param name       of the parameter.
+   * @param index      of the parameter in the method.
+   * @param type       fully qualified class name of the parameter type.
+   * @param builder    with the current method context.
+   */
+  void process(T annotation, String name, Integer index, String type,
+      TargetMethodDefinition.Builder builder);
+}

--- a/core/src/main/java/feign/contract/impl/BodyAnnotationProcessor.java
+++ b/core/src/main/java/feign/contract/impl/BodyAnnotationProcessor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019-2021 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.contract.impl;
+
+import feign.contract.Body;
+import feign.contract.ParameterAnnotationProcessor;
+import feign.contract.TargetMethodDefinition.Builder;
+
+/**
+ * Annotation Processor for the {@link Body} annotation. Registers which method parameters contains
+ * the request body.
+ */
+public class BodyAnnotationProcessor implements ParameterAnnotationProcessor<Body> {
+
+  @Override
+  public void process(Body annotation, String name, Integer index, String type, Builder builder) {
+    builder.body(index);
+  }
+}

--- a/core/src/main/java/feign/contract/impl/HeaderAnnotationProcessor.java
+++ b/core/src/main/java/feign/contract/impl/HeaderAnnotationProcessor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019-2021 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.contract.impl;
+
+import feign.contract.AnnotationProcessor;
+import feign.contract.Header;
+import feign.contract.TargetMethodDefinition.Builder;
+import feign.http.HttpHeader;
+
+/**
+ * Annotation processor for the {@link Header} annotation.  Evaluates and prepares an HTTP
+ * Header.
+ */
+public class HeaderAnnotationProcessor implements AnnotationProcessor<Header> {
+
+  @Override
+  public void process(Header annotation, Builder builder) {
+    HttpHeader httpHeader = new HttpHeader(annotation.name());
+    httpHeader.value(annotation.value());
+    builder.header(httpHeader);
+  }
+}

--- a/core/src/main/java/feign/contract/impl/HeadersAnnotationProcessor.java
+++ b/core/src/main/java/feign/contract/impl/HeadersAnnotationProcessor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019-2021 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.contract.impl;
+
+import feign.contract.AnnotationProcessor;
+import feign.contract.Header;
+import feign.contract.Headers;
+import feign.contract.TargetMethodDefinition.Builder;
+
+/**
+ * Annotation Processor for the {@link Headers} annotation.
+ */
+public class HeadersAnnotationProcessor implements AnnotationProcessor<Headers> {
+
+  private final HeaderAnnotationProcessor headerAnnotationProcessor;
+
+  /**
+   * Creates a new {@link HeadersAnnotationProcessor}.
+   */
+  public HeadersAnnotationProcessor() {
+    this.headerAnnotationProcessor = new HeaderAnnotationProcessor();
+  }
+
+  @Override
+  public void process(Headers annotation, Builder builder) {
+    Header[] headers = annotation.value();
+    if (headers.length != 0) {
+      for (Header value : headers) {
+        this.headerAnnotationProcessor.process(value, builder);
+      }
+    }
+  }
+}

--- a/core/src/main/java/feign/contract/impl/ParamAnnotationProcessor.java
+++ b/core/src/main/java/feign/contract/impl/ParamAnnotationProcessor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019-2021 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.contract.impl;
+
+import feign.contract.Param;
+import feign.contract.ParameterAnnotationProcessor;
+import feign.contract.TargetMethodDefinition.Builder;
+import feign.contract.TargetMethodParameterDefinition;
+import feign.template.ExpressionExpander;
+
+/**
+ * Annotation Processor for the {@link Param} annotation.  Registers the parameter, along with
+ * it's name, type and index in the method, with the method definition.
+ */
+public class ParamAnnotationProcessor implements ParameterAnnotationProcessor<Param> {
+
+  @Override
+  public void process(Param annotation, String name, Integer index, String type, Builder builder) {
+    Class<? extends ExpressionExpander> expanderClass = annotation.expander();
+    String expanderClassName = expanderClass.getName();
+
+    builder.parameterDefinition(
+        index, TargetMethodParameterDefinition.builder()
+            .name(annotation.value())
+            .index(index)
+            .type(type)
+            .expanderClassName(expanderClassName)
+            .build());
+  }
+}

--- a/core/src/main/java/feign/contract/impl/RequestAnnotationProcessor.java
+++ b/core/src/main/java/feign/contract/impl/RequestAnnotationProcessor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019-2021 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.contract.impl;
+
+import feign.contract.AnnotationProcessor;
+import feign.contract.Request;
+import feign.contract.TargetMethodDefinition.Builder;
+import feign.http.HttpMethod;
+import feign.support.StringUtils;
+
+/**
+ * Annotation processor for the {@link Request} annotation.  Responsible for parsing the top level
+ * request information.
+ */
+public class RequestAnnotationProcessor implements AnnotationProcessor<Request> {
+
+  /**
+   * Read the uri, request method, and other request specific configuration.
+   *
+   * @param annotation to evaluate.
+   * @param builder    with the current method context.
+   */
+  @Override
+  public void process(Request annotation, Builder builder) {
+    String uri = (StringUtils.isNotEmpty(annotation.uri())) ? annotation.uri() : annotation.value();
+    HttpMethod httpMethod = annotation.method();
+    boolean followRedirects = annotation.followRedirects();
+
+    builder.uri(uri)
+        .method(httpMethod)
+        .followRedirects(followRedirects)
+        .connectTimeout(annotation.connectTimeout())
+        .readTimeout(annotation.readTimeout());
+  }
+}

--- a/core/src/main/java/feign/impl/AbstractTargetMethodHandler.java
+++ b/core/src/main/java/feign/impl/AbstractTargetMethodHandler.java
@@ -246,7 +246,7 @@ public abstract class AbstractTargetMethodHandler implements TargetMethodHandler
    * @return the desired decoded result
    */
   protected Object decode(Response response) {
-    TypeDefinition typeDefinition = targetMethodDefinition.getReturnType();
+    TypeDefinition typeDefinition = targetMethodDefinition.getReturnTypeDefinition();
     Class<?> returnType = typeDefinition.getType();
     if (void.class == returnType || (response == null || response.body() == null)) {
       return null;

--- a/core/src/main/java/feign/impl/TypeDrivenMethodHandlerFactory.java
+++ b/core/src/main/java/feign/impl/TypeDrivenMethodHandlerFactory.java
@@ -24,8 +24,9 @@ import feign.impl.type.TypeDefinition;
 import java.util.concurrent.Future;
 
 /**
- * Target Method Handler Factory that uses the {@link TargetMethodDefinition#getReturnType()} to
- * determine which Method Handler to create.
+ * Target Method Handler Factory that uses the
+ * {@link TargetMethodDefinition#getReturnTypeDefinition()} to determine which Method Handler to
+ * create.
  */
 public class TypeDrivenMethodHandlerFactory implements TargetMethodHandlerFactory {
 
@@ -41,7 +42,7 @@ public class TypeDrivenMethodHandlerFactory implements TargetMethodHandlerFactor
   public TargetMethodHandler create(TargetMethodDefinition targetMethodDefinition,
       FeignConfiguration configuration) {
 
-    TypeDefinition typeDefinition = targetMethodDefinition.getReturnType();
+    TypeDefinition typeDefinition = targetMethodDefinition.getReturnTypeDefinition();
     if (isFuture(typeDefinition.getType())) {
       return new AsyncTargetMethodHandler(targetMethodDefinition, configuration);
     } else {

--- a/core/src/main/java/feign/impl/type/TypeDefinitionFactory.java
+++ b/core/src/main/java/feign/impl/type/TypeDefinitionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 OpenFeign Contributors
+ * Copyright 2019-2021 OpenFeign Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -221,5 +221,7 @@ public class TypeDefinitionFactory {
     /* we cannot go any further */
     return type;
   }
+
+
 
 }

--- a/core/src/main/java/feign/impl/type/TypeUtils.java
+++ b/core/src/main/java/feign/impl/type/TypeUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019-2021 OpenFeign Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feign.impl.type;
+
+/**
+ * Utility Class for working with Types and Class Name.
+ */
+public class TypeUtils {
+
+  /**
+   * Create a new Class instance for the class name provided.
+   *
+   * @param fullyQualifiedClassName to parse.
+   * @return the class instance, if found.
+   * @throws IllegalStateException if the class could not be found.
+   */
+  public static Class<?> getInstance(String fullyQualifiedClassName) {
+    try {
+      return Class.forName(fullyQualifiedClassName);
+    } catch (ClassNotFoundException cnfe) {
+      if (isPrimitiveType(fullyQualifiedClassName)) {
+        return getPrimitiveInstance(fullyQualifiedClassName);
+      }
+      throw new IllegalStateException("Error occurred obtaining class instance.", cnfe);
+    }
+  }
+
+  private static boolean isPrimitiveType(String type) {
+    return Boolean.TYPE.getName().equalsIgnoreCase(type)
+        || Character.TYPE.getName().equalsIgnoreCase(type)
+        || Byte.TYPE.getName().equalsIgnoreCase(type)
+        || Short.TYPE.getName().equalsIgnoreCase(type)
+        || Integer.TYPE.getName().equalsIgnoreCase(type)
+        || Long.TYPE.getName().equalsIgnoreCase(type)
+        || Float.TYPE.getName().equalsIgnoreCase(type)
+        || Double.TYPE.getName().equalsIgnoreCase(type)
+        || Void.TYPE.getName().equalsIgnoreCase(type);
+  }
+
+  private static Class<?> getPrimitiveInstance(String type) {
+    if (Boolean.TYPE.getName().equalsIgnoreCase(type)) {
+      return Boolean.TYPE;
+    } else if (Character.TYPE.getName().equalsIgnoreCase(type)) {
+      return Character.TYPE;
+    } else if (Byte.TYPE.getName().equalsIgnoreCase(type)) {
+      return Byte.TYPE;
+    } else if (Short.TYPE.getName().equalsIgnoreCase(type)) {
+      return Short.TYPE;
+    } else if (Integer.TYPE.getName().equalsIgnoreCase(type)) {
+      return Integer.TYPE;
+    } else if (Long.TYPE.getName().equalsIgnoreCase(type)) {
+      return Long.TYPE;
+    } else if (Float.TYPE.getName().equalsIgnoreCase(type)) {
+      return Float.TYPE;
+    } else if (Double.TYPE.getName().equalsIgnoreCase(type)) {
+      return Double.TYPE;
+    } else if (Void.TYPE.getName().equalsIgnoreCase(type)) {
+      return Void.TYPE;
+    }
+    throw new IllegalArgumentException("Not a primitive type " + type);
+  }
+
+}

--- a/core/src/test/java/feign/contract/FeignContractTest.java
+++ b/core/src/test/java/feign/contract/FeignContractTest.java
@@ -55,7 +55,7 @@ class FeignContractTest {
     /* verify each method is registered */
     assertThat(methodDefinitions).anyMatch(
         targetMethodDefinition -> targetMethodDefinition.getName().equalsIgnoreCase("get")
-            && targetMethodDefinition.getReturnType().getType() == String.class
+            && targetMethodDefinition.getReturnTypeDefinition().getType() == String.class
             && targetMethodDefinition.getMethod() == HttpMethod.GET
             && targetMethodDefinition.getParameterDefinitions().isEmpty()
             && targetMethodDefinition.getBody() == -1
@@ -66,7 +66,7 @@ class FeignContractTest {
     /* implicit body parameter */
     assertThat(methodDefinitions).anyMatch(
         targetMethodDefinition -> targetMethodDefinition.getName().equalsIgnoreCase("post")
-            && targetMethodDefinition.getReturnType().getType() == String.class
+            && targetMethodDefinition.getReturnTypeDefinition().getType() == String.class
             && targetMethodDefinition.getMethod() == HttpMethod.POST
             && targetMethodDefinition.getParameterDefinitions().contains(
             TargetMethodParameterDefinition.builder()
@@ -80,7 +80,7 @@ class FeignContractTest {
     /* explicit body parameter */
     assertThat(methodDefinitions).anyMatch(
         targetMethodDefinition -> targetMethodDefinition.getName().equalsIgnoreCase("put")
-            && targetMethodDefinition.getReturnType().getType() == String.class
+            && targetMethodDefinition.getReturnTypeDefinition().getType() == String.class
             && targetMethodDefinition.getMethod() == HttpMethod.PUT
             && targetMethodDefinition.getParameterDefinitions()
             .contains(TargetMethodParameterDefinition.builder()
@@ -94,7 +94,7 @@ class FeignContractTest {
     /* void return type */
     assertThat(methodDefinitions).anyMatch(
         targetMethodDefinition -> targetMethodDefinition.getName().equalsIgnoreCase("delete")
-            && targetMethodDefinition.getReturnType().getType() == void.class
+            && targetMethodDefinition.getReturnTypeDefinition().getType() == void.class
             && targetMethodDefinition.getMethod() == HttpMethod.DELETE
             && targetMethodDefinition.getParameterDefinitions()
             .contains(TargetMethodParameterDefinition.builder()
@@ -108,7 +108,7 @@ class FeignContractTest {
     /* request options and generic return type */
     assertThat(methodDefinitions).anyMatch(
         targetMethodDefinition -> targetMethodDefinition.getName().equalsIgnoreCase("search")
-            && targetMethodDefinition.getReturnType().getType() == List.class
+            && targetMethodDefinition.getReturnTypeDefinition().getType() == List.class
             && targetMethodDefinition.getMethod() == HttpMethod.GET
             && targetMethodDefinition.getParameterDefinitions().isEmpty()
             && targetMethodDefinition.getBody() == -1
@@ -119,7 +119,7 @@ class FeignContractTest {
     /* map parameter type */
     assertThat(methodDefinitions).anySatisfy(targetMethodDefinition -> {
       boolean properties = targetMethodDefinition.getName().equalsIgnoreCase("map")
-          && targetMethodDefinition.getReturnType().getType() == List.class
+          && targetMethodDefinition.getReturnTypeDefinition().getType() == List.class
           && targetMethodDefinition.getMethod() == HttpMethod.GET
           && targetMethodDefinition.getBody() == -1;
       assertThat(properties).isTrue();
@@ -134,7 +134,7 @@ class FeignContractTest {
     assertThat(methodDefinitions).anySatisfy(
         targetMethodDefinition -> {
           boolean properties = targetMethodDefinition.getName().equalsIgnoreCase("list")
-              && targetMethodDefinition.getReturnType().getType() == List.class
+              && targetMethodDefinition.getReturnTypeDefinition().getType() == List.class
               && targetMethodDefinition.getMethod() == HttpMethod.GET
               && targetMethodDefinition.getBody() == -1;
           assertThat(properties).isTrue();
@@ -148,7 +148,7 @@ class FeignContractTest {
     /* response return type */
     assertThat(methodDefinitions).anyMatch(
         targetMethodDefinition -> targetMethodDefinition.getName().equalsIgnoreCase("response")
-            && targetMethodDefinition.getReturnType().getType() == Response.class
+            && targetMethodDefinition.getReturnTypeDefinition().getType() == Response.class
             && targetMethodDefinition.getMethod() == HttpMethod.GET
             && targetMethodDefinition.getParameterDefinitions()
             .contains(TargetMethodParameterDefinition.builder()

--- a/core/src/test/java/feign/impl/AbstractTargetMethodHandlerTest.java
+++ b/core/src/test/java/feign/impl/AbstractTargetMethodHandlerTest.java
@@ -40,13 +40,11 @@ import feign.RequestInterceptor;
 import feign.Response;
 import feign.ResponseDecoder;
 import feign.Retry;
-import feign.contract.TargetMethodDefinition;
 import feign.TargetMethodHandler;
+import feign.contract.TargetMethodDefinition;
 import feign.contract.TargetMethodParameterDefinition;
 import feign.http.HttpMethod;
 import feign.http.RequestSpecification;
-import feign.impl.type.TypeDefinition;
-import feign.impl.type.TypeDefinitionFactory;
 import feign.retry.NoRetry;
 import feign.template.ExpanderRegistry;
 import feign.template.expander.CachingExpanderRegistry;
@@ -92,8 +90,6 @@ class AbstractTargetMethodHandlerTest {
   @Mock
   private FeignConfiguration configuration;
 
-  private final TypeDefinitionFactory typeDefinitionFactory = new TypeDefinitionFactory();
-
   private final RequestInterceptor interceptor = RequestInterceptor.identity();
 
   private final Retry retry = new NoRetry();
@@ -118,9 +114,7 @@ class AbstractTargetMethodHandlerTest {
   void interceptors_areApplied_ifPresent() throws Throwable {
     when(this.client.request(any(Request.class))).thenReturn(this.response);
     when(this.response.body()).thenReturn(mock(InputStream.class));
-    TypeDefinition returnType = this.typeDefinitionFactory
-        .create(String.class, TestInterface.class);
-    this.targetMethodDefinition.returnType(returnType)
+    this.targetMethodDefinition.returnTypeFullyQualifiedClassName(String.class.getName())
         .target(new AbsoluteUriTarget("http://localhost"))
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
@@ -147,9 +141,7 @@ class AbstractTargetMethodHandlerTest {
   void interceptors_areNotApplied_ifNotPresent() throws Throwable {
     when(this.client.request(any(Request.class))).thenReturn(this.response);
     when(this.response.body()).thenReturn(mock(InputStream.class));
-    TypeDefinition returnType = this.typeDefinitionFactory
-        .create(String.class, TestInterface.class);
-    this.targetMethodDefinition.returnType(returnType)
+    this.targetMethodDefinition.returnTypeFullyQualifiedClassName(String.class.getName())
         .target(new AbsoluteUriTarget("http://localhost"))
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
@@ -201,9 +193,7 @@ class AbstractTargetMethodHandlerTest {
           }
         });
 
-    TypeDefinition returnType = this.typeDefinitionFactory
-        .create(String.class, TestInterface.class);
-    this.targetMethodDefinition.returnType(returnType)
+    this.targetMethodDefinition.returnTypeFullyQualifiedClassName(String.class.getName())
         .target(new AbsoluteUriTarget("http://localhost"))
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
@@ -232,10 +222,7 @@ class AbstractTargetMethodHandlerTest {
     when(this.client.request(any(Request.class))).thenReturn(this.response);
     when(this.response.body()).thenReturn(mock(InputStream.class));
 
-    TypeDefinition returnType = this.typeDefinitionFactory
-        .create(String.class, TestInterface.class);
-
-    this.targetMethodDefinition.returnType(returnType)
+    this.targetMethodDefinition.returnTypeFullyQualifiedClassName(String.class.getName())
         .target(new AbsoluteUriTarget("http://localhost"))
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
@@ -262,10 +249,7 @@ class AbstractTargetMethodHandlerTest {
     when(this.client.request(any(Request.class))).thenReturn(this.response);
     when(this.response.body()).thenReturn(mock(InputStream.class));
 
-    TypeDefinition returnType = this.typeDefinitionFactory
-        .create(Response.class, TestInterface.class);
-
-    this.targetMethodDefinition.returnType(returnType)
+    this.targetMethodDefinition.returnTypeFullyQualifiedClassName(Response.class.getName())
         .target(new AbsoluteUriTarget("http://localhost"))
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
@@ -290,10 +274,7 @@ class AbstractTargetMethodHandlerTest {
   @Test
   void skipDecode_ifResponseIsNull() throws Throwable {
 
-    TypeDefinition returnType = this.typeDefinitionFactory
-        .create(Response.class, TestInterface.class);
-
-    this.targetMethodDefinition.returnType(returnType)
+    this.targetMethodDefinition.returnTypeFullyQualifiedClassName(Response.class.getName())
         .target(new AbsoluteUriTarget("http://localhost"))
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
@@ -319,10 +300,7 @@ class AbstractTargetMethodHandlerTest {
   void skipDecode_ifResponseBody_isNull() throws Throwable {
     when(this.client.request(any(Request.class))).thenReturn(this.response);
 
-    TypeDefinition returnType = this.typeDefinitionFactory
-        .create(Response.class, TestInterface.class);
-
-    this.targetMethodDefinition.returnType(returnType)
+    this.targetMethodDefinition.returnTypeFullyQualifiedClassName(Response.class.getName())
         .target(new AbsoluteUriTarget("http://localhost"))
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
@@ -348,9 +326,7 @@ class AbstractTargetMethodHandlerTest {
   void skipDecode_ifReturnType_Void() throws Throwable {
     when(this.client.request(any(Request.class))).thenReturn(this.response);
 
-    TypeDefinition returnType = this.typeDefinitionFactory
-        .create(void.class, TestInterface.class);
-    this.targetMethodDefinition.returnType(returnType)
+    this.targetMethodDefinition.returnTypeFullyQualifiedClassName(void.class.getName())
         .target(new AbsoluteUriTarget("http://localhost"))
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
@@ -378,10 +354,7 @@ class AbstractTargetMethodHandlerTest {
       throw new RuntimeException("Broken");
     };
 
-    TypeDefinition returnType = this.typeDefinitionFactory
-        .create(Response.class, TestInterface.class);
-
-    this.targetMethodDefinition.returnType(returnType)
+    this.targetMethodDefinition.returnTypeFullyQualifiedClassName(Response.class.getName())
         .target(new AbsoluteUriTarget("http://localhost"))
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
@@ -411,10 +384,7 @@ class AbstractTargetMethodHandlerTest {
   void whenExceptionOccursDuringRequest_exceptionHandlerIsCalled() {
     when(this.client.request(any(Request.class))).thenThrow(new RuntimeException("Broken"));
 
-    TypeDefinition returnType = this.typeDefinitionFactory
-        .create(String.class, TestInterface.class);
-
-    this.targetMethodDefinition.returnType(returnType)
+    this.targetMethodDefinition.returnTypeFullyQualifiedClassName(String.class.getName())
         .target(new AbsoluteUriTarget("http://localhost"))
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
@@ -443,10 +413,7 @@ class AbstractTargetMethodHandlerTest {
     when(this.response.body()).thenReturn(mock(InputStream.class));
     when(this.decoder.decode(any(Response.class), any())).thenThrow(new RuntimeException("bad"));
 
-    TypeDefinition returnType = this.typeDefinitionFactory
-        .create(String.class, TestInterface.class);
-
-    this.targetMethodDefinition.returnType(returnType)
+    this.targetMethodDefinition.returnTypeFullyQualifiedClassName(String.class.getName())
         .target(new AbsoluteUriTarget("http://localhost"))
         .uri("/resources/{name}")
         .method(HttpMethod.GET)
@@ -477,10 +444,7 @@ class AbstractTargetMethodHandlerTest {
   @Test
   void ensureTemplateParameters_areCached() {
 
-    TypeDefinition returnType = this.typeDefinitionFactory
-        .create(String.class, TestInterface.class);
-
-    this.targetMethodDefinition.returnType(returnType)
+    this.targetMethodDefinition.returnTypeFullyQualifiedClassName(String.class.getName())
         .target(new AbsoluteUriTarget("http://localhost"))
         .uri("/resources/{name}")
         .method(HttpMethod.GET)

--- a/core/src/test/java/feign/impl/BlockingTargetMethodHandlerTest.java
+++ b/core/src/test/java/feign/impl/BlockingTargetMethodHandlerTest.java
@@ -26,12 +26,10 @@ import feign.FeignConfiguration;
 import feign.Logger;
 import feign.RequestEncoder;
 import feign.ResponseDecoder;
-import feign.Retry;
-import feign.contract.TargetMethodDefinition;
 import feign.TargetMethodHandler;
 import feign.contract.Request;
+import feign.contract.TargetMethodDefinition;
 import feign.http.HttpMethod;
-import feign.impl.type.TypeDefinitionFactory;
 import feign.retry.NoRetry;
 import feign.support.AuditingExecutor;
 import java.util.Collections;
@@ -45,8 +43,6 @@ class BlockingTargetMethodHandlerTest {
 
   @Mock
   private FeignConfiguration configuration;
-
-  private final TypeDefinitionFactory typeDefinitionFactory = new TypeDefinitionFactory();
 
   @Test
   void usingDefaultExecutor_willUseTheCallingThread() throws Throwable {
@@ -63,7 +59,7 @@ class BlockingTargetMethodHandlerTest {
         .thenReturn(Collections.emptyList());
 
     TargetMethodDefinition.Builder builder = TargetMethodDefinition.builder(Blog.class.getName());
-    builder.returnType(this.typeDefinitionFactory.create(void.class, Blog.class))
+    builder.returnTypeFullyQualifiedClassName(void.class.getName())
         .uri("/resources/{name}")
         .method(HttpMethod.GET);
 
@@ -83,6 +79,7 @@ class BlockingTargetMethodHandlerTest {
     assertThat(executor.getExecutionCount()).isEqualTo(6);
   }
 
+  @SuppressWarnings("unused")
   interface Blog {
 
     @Request(value = "/")

--- a/core/src/test/java/feign/impl/TypeDrivenMethodHandlerFactoryTest.java
+++ b/core/src/test/java/feign/impl/TypeDrivenMethodHandlerFactoryTest.java
@@ -29,7 +29,6 @@ import feign.ResponseDecoder;
 import feign.Retry;
 import feign.TargetMethodHandler;
 import feign.contract.TargetMethodDefinition;
-import feign.impl.type.TypeDefinitionFactory;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -45,8 +44,6 @@ class TypeDrivenMethodHandlerFactoryTest {
 
   @Mock
   private FeignConfiguration configuration;
-
-  private final TypeDefinitionFactory typeDefinitionFactory = new TypeDefinitionFactory();
 
   private TargetMethodDefinition.Builder targetMethodDefinition;
 
@@ -71,7 +68,7 @@ class TypeDrivenMethodHandlerFactoryTest {
   void createsBlockingHandler_byDefault() {
     this.targetMethodDefinition =
         TargetMethodDefinition.builder(Blog.class.getName());
-    targetMethodDefinition.returnType(this.typeDefinitionFactory.create(String.class, Blog.class))
+    targetMethodDefinition.returnTypeFullyQualifiedClassName(String.class.getName())
         .target(new AbsoluteUriTarget("http://localhost"));
 
     TargetMethodHandler targetMethodHandler =
@@ -84,7 +81,7 @@ class TypeDrivenMethodHandlerFactoryTest {
   void createsAsyncHandler_whenReturnType_isFuture() {
     this.targetMethodDefinition =
         TargetMethodDefinition.builder(Blog.class.getName());
-    targetMethodDefinition.returnType(this.typeDefinitionFactory.create(Future.class, Blog.class))
+    targetMethodDefinition.returnTypeFullyQualifiedClassName(Future.class.getName())
         .target(new AbsoluteUriTarget("http://localhost"));
 
     TargetMethodHandler targetMethodHandler =
@@ -98,7 +95,7 @@ class TypeDrivenMethodHandlerFactoryTest {
     this.targetMethodDefinition =
         TargetMethodDefinition.builder(Blog.class.getName());
     targetMethodDefinition
-        .returnType(this.typeDefinitionFactory.create(CompletableFuture.class, Blog.class))
+        .returnTypeFullyQualifiedClassName(CompletableFuture.class.getName())
         .target(new AbsoluteUriTarget("http://localhost"));
 
     TargetMethodHandler targetMethodHandler =


### PR DESCRIPTION
### Summary of changes 

This change introduces the concept of an `AnnotationProcessor`.
These components are used when processing an `AnnotationDrivenContract`

Contracts can now be modularized whereas they are now collections of
annotation processors instead of full fledged parsing components.

By doing so, `AnnotationProcessors` can be shared between our current
reflection based contract parsers and the upcoming compile time annotation
processors.
